### PR TITLE
Normalizing App Structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 *.pyc
 *.egg-info
 data*
+.DS_Store
+build/
+dist/
+venv/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/casper/daemon/app.py
+++ b/casper/daemon/app.py
@@ -10,10 +10,13 @@ import gevent
 from gevent.event import Event
 
 import ethereum.slogging as slogging
-from casper_service import CasperService
-from chain_service import ChainService
-from accounts import AccountsService, Account
-from db_service import DBService
+
+# import casper stuff
+from casper.daemon.casper_service import CasperService
+from casper.daemon.chain_service import ChainService
+from casper.daemon.accounts import AccountsService, Account
+from casper.daemon.db_service import DBService
+
 from devp2p.app import BaseApp
 from devp2p.discovery import NodeDiscovery
 from devp2p.peermanager import PeerManager

--- a/casper/daemon/casper_protocol.py
+++ b/casper/daemon/casper_protocol.py
@@ -1,5 +1,5 @@
 import rlp
-from casper_messages import PrepareMessage, CommitMessage
+from casper.daemon.casper_messages import PrepareMessage, CommitMessage
 from devp2p.protocol import BaseProtocol, SubProtocolError
 from ethereum import slogging
 

--- a/casper/daemon/casper_service.py
+++ b/casper/daemon/casper_service.py
@@ -1,10 +1,10 @@
 import traceback
-from casper_messages import InvalidCasperMessage, PrepareMessage
-from casper_protocol import CasperProtocol
+from casper.daemon.casper_messages import InvalidCasperMessage, PrepareMessage
+from casper.daemon.casper_protocol import CasperProtocol
 from devp2p.service import WiredService
 from ethereum import slogging
 from ethereum.utils import encode_hex, sha3
-from leveldb_store import LevelDBStore
+from casper.daemon.leveldb_store import LevelDBStore
 
 log = slogging.get_logger('casper.service')
 

--- a/casper/daemon/leveldb_store.py
+++ b/casper/daemon/leveldb_store.py
@@ -1,8 +1,8 @@
 import json
 
 import rlp
-from casper_messages import PrepareMessage
-from validators import Validator
+from casper.daemon.casper_messages import PrepareMessage
+from casper.daemon.validators import Validator
 from ethereum.utils import encode_hex
 from ethereum import slogging
 
@@ -238,4 +238,3 @@ class LevelDBStore(object):
 
     def get_int(self, k):
         return rlp.decode(self.db.get(k), sedes=rlp.sedes.big_endian_int)
-

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from setuptools import setup
+from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
 
@@ -19,22 +19,11 @@ class PyTest(TestCommand):
         errno = pytest.main(self.test_args)
         raise SystemExit(errno)
 
-
-INSTALL_REQUIRES_REPLACEMENTS = {}
-INSTALL_REQUIRES = list()
-with open('requirements.txt') as requirements_file:
-    for requirement in requirements_file:
-        # install_requires will break on git URLs, so skip them
-        if 'git+' in requirement:
-            continue
-        dependency = INSTALL_REQUIRES_REPLACEMENTS.get(
-            requirement.strip(),
-            requirement.strip(),
-        )
-
-        INSTALL_REQUIRES.append(dependency)
-
-INSTALL_REQUIRES = list(set(INSTALL_REQUIRES))
+install_requires = set(x.strip() for x in open('requirements.txt'))
+install_requires_replacements = {
+    'git+https://github.com/ethereum/pyethereum.git@state_revamp': 'ethereum',
+}
+install_requires = [install_requires_replacements.get(r, r) for r in install_requires]
 
 # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
 # see: https://github.com/ethereum/pyethapp/wiki/Development:-Versions-and-Releases
@@ -47,9 +36,7 @@ setup(
     author='Ethereum Foundation',
     author_email='info@ethereum.org',
     url='https://github.com/ethereum/casper',
-    packages=[
-        'casper',
-    ],
+    packages=['casper'],
     package_data={},
     license='MIT',
     zip_safe=False,
@@ -67,10 +54,9 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
     cmdclass={'test': PyTest},
-    install_requires=INSTALL_REQUIRES,
+    install_requires=install_requires,
     tests_require=[],
-    entry_points='''
-    [console_scripts]
-    casper=casper.daemon.app:app
-    '''
+    entry_points={
+    'console_scripts':['casper-daemon=casper.daemon.app:app']
+    }
 )


### PR DESCRIPTION
The main goal of this PR is to create the setup.py file in a similar manner to that of pyethereum and to ensure that the entry point works for the casper daemon after a `python3 setup.py install`

- Adding a MANIFEST.in 
- Changing the entry_points syntax to `casper-daemon`
- Installing from requirements.txt via setup.py in the same manner as in pyethereum
- Adding full paths to imports across the repo
- Updating .gitignore to include more unwanted files