### PR TITLE
`Vote()` refactor

### DIFF
--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -218,8 +218,8 @@ def get_collective_reward() -> decimal:
     if not self.deposit_exists() or not live:
         return 0.0
     # Fraction that voted
-    cur_vote_frac = self.checkpoints[epoch - 1].cur_dyn_votes[self.expected_source_epoch] / self.total_curdyn_deposits
-    prev_vote_frac = self.checkpoints[epoch - 1].prev_dyn_votes[self.expected_source_epoch] / self.total_prevdyn_deposits
+    cur_vote_frac = self.checkpoints[epoch - 1].cur_dyn_vote_amount[self.expected_source_epoch] / self.total_curdyn_deposits
+    prev_vote_frac = self.checkpoints[epoch - 1].prev_dyn_vote_amount[self.expected_source_epoch] / self.total_prevdyn_deposits
     vote_frac = min(cur_vote_frac, prev_vote_frac)
     return vote_frac * self.reward_factor / 2
 

--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -377,9 +377,6 @@ def proc_reward(validator_index: num, reward: num(wei/m)):
 # Extract values from vote_msg. Returns tuple.
 @private
 def extract_msg_from_vote(vote_msg: bytes <= 1024) -> (num, bytes32, num, num, bytes <= 1024):
-    # Get hash for signature, and implicitly assert that it is an RLP list
-    # consisting solely of RLP elements
-    sighash = extract32(raw_call(self.sighasher, vote_msg, gas=200000, outsize=32), 0)
     # Extract parameters
     values = RLPList(vote_msg, [num, bytes32, num, num, bytes])
     validator_index = values[0]
@@ -392,7 +389,14 @@ def extract_msg_from_vote(vote_msg: bytes <= 1024) -> (num, bytes32, num, num, b
 # Check the conditions for valid vote are met.
 @private
 # TODO: Viper tuples as a param or struct support?
-def check_valid_vote(validator_index: num, target_hash: bytes32, target_epoch: num, source_epoch: num, sig: bytes <= 1024):
+def check_valid_vote(validator_index: num,
+                     target_hash: bytes32,
+                     target_epoch: num,
+                     source_epoch: num,
+                     sig: bytes <= 1024,
+                     vote_msg: bytes <= 1024):
+    # Get hash for signature, and implicitly assert that it is an RLP list consisting solely of RLP elements
+    sighash = extract32(raw_call(self.sighasher, vote_msg, gas=200000, outsize=32), 0)
     # Check the signature
     assert extract32(raw_call(self.validators[validator_index].addr, concat(sighash, sig), gas=500000, outsize=32), 0) == as_bytes32(1)
     # Check that this vote has not yet been made
@@ -406,7 +410,11 @@ def check_valid_vote(validator_index: num, target_hash: bytes32, target_epoch: n
     # assert block.number % self.epoch_length >= self.epoch_length / 4
 
 @private
-def record_vote(validator_index: num, target_hash: bytes32, target_epoch: num, source_epoch: num, sig: bytes <= 1024):
+def record_vote(validator_index: num,
+                target_hash: bytes32,
+                target_epoch: num,
+                source_epoch: num,
+                sig: bytes <= 1024):
     # Record that the validator voted for this target epoch so they can't again
     self.checkpoints[target_epoch].vote_bitmap[target_hash][validator_index / 256] = \
         bitwise_or(self.checkpoints[target_epoch].vote_bitmap[target_hash][validator_index / 256],
@@ -433,7 +441,7 @@ def record_vote(validator_index: num, target_hash: bytes32, target_epoch: num, s
 @public
 def submit_vote(vote_msg: bytes <= 1024):
     validator_index, target_hash, target_epoch, source_epoch, _sig = self.extract_msg_from_vote(vote_msg)
-    self.check_valid_vote(validator_index, target_hash, target_epoch, source_epoch, sig)
+    self.check_valid_vote(validator_index, target_hash, target_epoch, source_epoch, sig, vote_msg)
 
     # Keep track of vote and increment vote amount.
     self.record_vote(validator_index, target_hash, target_epoch, source_epoch, sig)

--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -144,7 +144,7 @@ def __init__(  # Epoch length, delay in epochs for withdrawing
     # Constants that affect interest rates and penalties
     self.base_interest_factor = _base_interest_factor
     self.base_penalty_factor = _base_penalty_factor
-    self.vote_log_topic = sha3("submit_vote()")
+    self.vote_log_topic = sha3("vote()")
 
 # ***** Constants *****
 @public
@@ -440,7 +440,7 @@ def record_vote(validator_index: num,
 # Process a vote message
 # TODO: Revise everything that calls it.
 @public
-def submit_vote(vote_msg: bytes <= 1024):
+def vote(vote_msg: bytes <= 1024):
     # Extract parameters
     values = RLPList(vote_msg, [num, bytes32, num, num, bytes])
     validator_index = values[0]

--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -376,7 +376,7 @@ def proc_reward(validator_index: num, reward: num(wei/m)):
 
 # Extract values from vote_msg. Returns tuple.
 @private
-def extract_msg_from_vote(vote_msg: bytes <= 1024) -> (num, bytes32, num, num, bytes):
+def extract_msg_from_vote(vote_msg: bytes <= 1024) -> (num, bytes32, num, num, bytes <= 1024):
     # Get hash for signature, and implicitly assert that it is an RLP list
     # consisting solely of RLP elements
     sighash = extract32(raw_call(self.sighasher, vote_msg, gas=200000, outsize=32), 0)
@@ -392,7 +392,7 @@ def extract_msg_from_vote(vote_msg: bytes <= 1024) -> (num, bytes32, num, num, b
 # Check the conditions for valid vote are met.
 @private
 # TODO: Viper tuples as a param or struct support?
-def check_valid_vote(validator_index: num, target_hash: bytes32, target_epoch: num, source_epoch: num, sig: bytes):
+def check_valid_vote(validator_index: num, target_hash: bytes32, target_epoch: num, source_epoch: num, sig: bytes <= 1024):
     # Check the signature
     assert extract32(raw_call(self.validators[validator_index].addr, concat(sighash, sig), gas=500000, outsize=32), 0) == as_bytes32(1)
     # Check that this vote has not yet been made
@@ -406,7 +406,7 @@ def check_valid_vote(validator_index: num, target_hash: bytes32, target_epoch: n
     # assert block.number % self.epoch_length >= self.epoch_length / 4
 
 @private
-def record_vote(validator_index: num, target_hash: bytes32, target_epoch: num, source_epoch: num, sig: bytes):
+def record_vote(validator_index: num, target_hash: bytes32, target_epoch: num, source_epoch: num, sig: bytes <= 1024):
     # Record that the validator voted for this target epoch so they can't again
     self.checkpoints[target_epoch].vote_bitmap[target_hash][validator_index / 256] = \
         bitwise_or(self.checkpoints[target_epoch].vote_bitmap[target_hash][validator_index / 256],

--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -428,7 +428,7 @@ def record_vote(validator_index: num,
     is_in_prev_dynasty = start_dynasty <= past_dynasty and past_dynasty < end_dynasty
 
     # Check if in past two dynasties to allow for dynamic validator sets.
-    assert is_in_current_dynasty(validator_index) or is_in_prev_dynasty(validator_index)
+    assert is_in_current_dynasty or is_in_prev_dynasty
 
     # Record that this vote took place
     if is_in_current_dynasty:

--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -269,7 +269,7 @@ def initialize_epoch(epoch: num):
     self.current_epoch = epoch
 
     # Reward if finalized at least in the last two epochs
-    self.last_nonvoter_rescale = (1 + self.get_collective_reward(epoch) - self.reward_factor)
+    self.last_nonvoter_rescale = (1 + self.get_collective_reward() - self.reward_factor)
     self.last_voter_rescale = self.last_nonvoter_rescale * (1 + self.reward_factor)
     self.deposit_scale_factor[epoch] = self.deposit_scale_factor[epoch - 1] * self.last_nonvoter_rescale
 
@@ -280,11 +280,11 @@ def initialize_epoch(epoch: num):
         # ESF is only thing that is changing and reward_factor is being used above.
         assert self.reward_factor > 0
     else:
-        self.insta_finalize(epoch)  # TODO: comment on why.
+        self.insta_finalize()  # TODO: comment on why.
         self.reward_factor = 0
 
     # Increment the dynasty if finalized
-    self.increment_dynasty(epoch)
+    self.increment_dynasty()
     # Store checkpoint hash for easy access
     self.checkpoint_hashes[epoch] = self.get_recommended_target_hash()
 

--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -40,12 +40,14 @@ dynasty_start_epoch: public(num[num])
 # Mapping of epoch to what dynasty it is
 dynasty_in_epoch: public(num[num])
 
+# TODO: Better comment here.
+# TODO: does this break anything outside?
 # Information for use in processing cryptoeconomic commitments
-votes: public({
+checkpoints: public({
     # How many votes are there for this source epoch from the current dynasty
-    cur_dyn_votes: decimal(wei / m)[num],
+    cur_dyn_vote_amount: decimal(wei / m)[num],
     # From the previous dynasty
-    prev_dyn_votes: decimal(wei / m)[num],
+    prev_dyn_vote_amount: decimal(wei / m)[num],
     # Bitmap of which validator IDs have already voted
     vote_bitmap: num256[num][bytes32],
     # Is a vote referencing the given epoch justified?
@@ -55,6 +57,7 @@ votes: public({
 }[num])  # index: target epoch
 
 # Is the current expected hash justified
+# TODO: do we need `main_hash_finalized`?
 main_hash_justified: public(bool)
 
 # Value used to calculate the per-epoch fee that validators should be charged
@@ -132,21 +135,21 @@ def __init__(  # Epoch length, delay in epochs for withdrawing
     self.sighasher = _sighasher
     # Set the purity checker address
     self.purity_checker = _purity_checker
-    # self.votes[0].committed = True
+    # self.checkpoints[0].committed = True
     # Set initial total deposit counter
     self.total_curdyn_deposits = 0
     self.total_prevdyn_deposits = 0
     # Constants that affect interest rates and penalties
     self.base_interest_factor = _base_interest_factor
     self.base_penalty_factor = _base_penalty_factor
-    self.vote_log_topic = sha3("vote()")
+    self.vote_log_topic = sha3("submit_vote()")
 
 # ***** Constants *****
 @public
 @constant
 def get_main_hash_voted_frac() -> decimal:
-    return min(self.votes[self.current_epoch].cur_dyn_votes[self.expected_source_epoch] / self.total_curdyn_deposits,
-               self.votes[self.current_epoch].prev_dyn_votes[self.expected_source_epoch] / self.total_prevdyn_deposits)
+    return min(self.checkpoints[self.current_epoch].cur_dyn_vote_amount[self.expected_source_epoch] / self.total_curdyn_deposits,
+               self.checkpoints[self.current_epoch].prev_dyn_vote_amount[self.expected_source_epoch] / self.total_prevdyn_deposits)
 
 @public
 @constant
@@ -172,7 +175,7 @@ def get_recommended_source_epoch() -> num:
 @public
 @constant
 def get_recommended_target_hash() -> bytes32:
-    return blockhash(self.current_epoch*self.epoch_length-1)
+    return blockhash(self.current_epoch * self.epoch_length - 1)
 
 # Called at the start of any epoch
 @public
@@ -180,7 +183,7 @@ def initialize_epoch(epoch: num):
     # Check that the epoch actually has started
     computed_current_epoch = block.number / self.epoch_length
     assert epoch <= computed_current_epoch and epoch == self.current_epoch + 1
-    # Set the epoch number
+    # Set the epoch number (this is the only place it is and should be set).
     self.current_epoch = epoch
 
     # Are both dynasties nonempty
@@ -200,16 +203,17 @@ def initialize_epoch(epoch: num):
     # 2 epochs to finalize.
     if deposit_exists and d <= 2:
         # Fraction that voted
-        cur_vote_frac = self.votes[epoch - 1].cur_dyn_votes[self.expected_source_epoch] / self.total_curdyn_deposits
-        prev_vote_frac = self.votes[epoch - 1].prev_dyn_votes[self.expected_source_epoch] / self.total_prevdyn_deposits
+        cur_vote_frac = self.checkpoints[epoch - 1].cur_dyn_vote_amount[self.expected_source_epoch] / self.total_curdyn_deposits
+        prev_vote_frac = self.checkpoints[epoch - 1].prev_dyn_vote_amount[self.expected_source_epoch] / self.total_prevdyn_deposits
         vote_frac = min(cur_vote_frac, prev_vote_frac)
         collective_virtue_reward = vote_frac * self.reward_factor / 2
     if not deposit_exists:
-        # If either current or prev dynasty is empty, and all hashes justify and finalize
-        self.main_hash_justified = True
-        self.votes[epoch - 1].is_justified = True
-        self.votes[epoch - 1].is_finalized = True
+        # If either current or prev dynasty is empty, and all hashes justify
+        self.checkpoints[epoch - 1].is_justified = True
         self.last_justified_epoch = epoch - 1
+        self.main_hash_justified = True
+        # and finalize.
+        self.checkpoints[epoch - 1].is_finalized = True
         self.last_finalized_epoch = epoch - 1
 
     # Adjust counters for interest
@@ -227,7 +231,7 @@ def initialize_epoch(epoch: num):
         self.reward_factor = 0
 
     # Increment the dynasty if finalized
-    if self.votes[epoch-2].is_finalized:
+    if self.checkpoints[epoch - 2].is_finalized:
         self.dynasty += 1
         self.total_prevdyn_deposits = self.total_curdyn_deposits
         self.total_curdyn_deposits += self.next_dynasty_wei_delta
@@ -323,9 +327,10 @@ def proc_reward(validator_index: num, reward: num(wei/m)):
     if current_dynasty == end_dynasty - 2:
         self.second_next_dynasty_wei_delta -= reward
 
-# Process a vote message
-@public
-def vote(vote_msg: bytes <= 1024):
+# Extract values from vote_msg. Returns tuple.
+@private
+# TODO: make custom type for bytes <= 1024?
+def extract_msg_from_vote(vote_msg: bytes <= 1024) -> (num, bytes32, num, num, bytes):
     # Get hash for signature, and implicitly assert that it is an RLP list
     # consisting solely of RLP elements
     sighash = extract32(raw_call(self.sighasher, vote_msg, gas=200000, outsize=32), 0)
@@ -336,60 +341,106 @@ def vote(vote_msg: bytes <= 1024):
     target_epoch = values[2]
     source_epoch = values[3]
     sig = values[4]
+    return validator_index, target_hash, target_epoch, source_epoch, sig
+
+@private
+def in_current_dynasty(validator_index: num) -> bool:
+    start_dynasty = self.validators[validator_index].start_dynasty
+    end_dynasty = self.validators[validator_index].end_dynasty
+    current_dynasty = self.dynasty_in_epoch[target_epoch]
+    in_current_dynasty = start_dynasty <= current_dynasty and current_dynasty < end_dynasty
+    return in_current_dynasty
+
+@private
+def in_previous_dynasty(validator_index: num) -> bool:
+    start_dynasty = self.validators[validator_index].start_dynasty
+    end_dynasty = self.validators[validator_index].end_dynasty
+    current_dynasty = self.dynasty_in_epoch[target_epoch]
+    past_dynasty = current_dynasty - 1
+    in_prev_dynasty = ((start_dynasty <= past_dynasty) and (past_dynasty < end_dynasty))
+    return in_prev_dynasty
+
+# Check the conditions for valid vote are met.
+@private
+# TODO: If viper supports tuple params, take that instead.
+def check_valid_vote(validator_index: num, target_hash: bytes32, target_epoch: num, source_epoch: num, sig: bytes):
     # Check the signature
     assert extract32(raw_call(self.validators[validator_index].addr, concat(sighash, sig), gas=500000, outsize=32), 0) == as_bytes32(1)
     # Check that this vote has not yet been made
-    assert not bitwise_and(self.votes[target_epoch].vote_bitmap[target_hash][validator_index / 256],
+    assert not bitwise_and(self.checkpoints[target_epoch].vote_bitmap[target_hash][validator_index / 256],
                            shift(as_num256(1), validator_index % 256))
     # Check that the vote's target hash is correct
     assert target_hash == self.get_recommended_target_hash()
     # Check that the vote source points to a justified epoch
-    assert self.votes[source_epoch].is_justified
+    assert self.checkpoints[source_epoch].is_justified
     # Check that we are at least (epoch length / 4) blocks into the epoch
     # assert block.number % self.epoch_length >= self.epoch_length / 4
-    # Original starting dynasty of the validator; fail if before
-    start_dynasty = self.validators[validator_index].start_dynasty
-    # Ending dynasty of the current login period
-    end_dynasty = self.validators[validator_index].end_dynasty
-    # Dynasty of the vote
-    current_dynasty = self.dynasty_in_epoch[target_epoch]
-    past_dynasty = current_dynasty - 1
-    in_current_dynasty = ((start_dynasty <= current_dynasty) and (current_dynasty < end_dynasty))
-    in_prev_dynasty = ((start_dynasty <= past_dynasty) and (past_dynasty < end_dynasty))
-    assert in_current_dynasty or in_prev_dynasty
+    # Check if in past two dynasties to allow for dynamic validator sets.
+    assert self.in_current_dynasty(validator_index) or self.in_previous_dynasty(validator_index)
+
+@private
+def record_vote(validator_index: num, target_hash: bytes32, target_epoch: num, source_epoch: num, sig: bytes,
+                cur_dyn_vote_amount: decimal, prev_dyn_vote_amount: decimal):
     # Record that the validator voted for this target epoch so they can't again
-    self.votes[target_epoch].vote_bitmap[target_hash][validator_index / 256] = \
-        bitwise_or(self.votes[target_epoch].vote_bitmap[target_hash][validator_index / 256],
+    self.checkpoints[target_epoch].vote_bitmap[target_hash][validator_index / 256] = \
+        bitwise_or(self.checkpoints[target_epoch].vote_bitmap[target_hash][validator_index / 256],
                    shift(as_num256(1), validator_index % 256))
     # Record that this vote took place
-    current_dynasty_votes = self.votes[target_epoch].cur_dyn_votes[source_epoch]
-    previous_dynasty_votes = self.votes[target_epoch].prev_dyn_votes[source_epoch]
-    if in_current_dynasty:
-        current_dynasty_votes += self.validators[validator_index].deposit
-        self.votes[target_epoch].cur_dyn_votes[source_epoch] = current_dynasty_votes
-    if in_prev_dynasty:
-        previous_dynasty_votes += self.validators[validator_index].deposit
-        self.votes[target_epoch].prev_dyn_votes[source_epoch] = previous_dynasty_votes
-    # Process rewards.
-    # Check that we have not yet voted for this target_epoch
-    # Pay the reward if the vote was submitted in time and the vote is voting the correct data
-    if self.current_epoch == target_epoch and self.expected_source_epoch == source_epoch:
-        reward = floor(self.validators[validator_index].deposit * self.reward_factor)
+    # TODO: too much overhead. not make it function
+    if self.in_current_dynasty(validator_index):
+        cur_dyn_vote_amount += self.validators[validator_index].deposit
+        self.checkpoints[target_epoch].cur_dyn_vote_amount[source_epoch] = cur_dyn_vote_amount
+    if self.in_prevous_dynasty(validator_index):
+        prev_dyn_vote_amount += self.validators[validator_index].deposit
+        self.checkpoints[target_epoch].prev_dyn_vote_amount[source_epoch] = prev_dyn_vote_amount
+
+@private
+# TODO: find all place where this should be used instead.
+def justify_epoch(e: num):
+    self.checkpoints[e].is_justified = True
+    self.last_justified_epoch = e
+    if e == self.current_epoch:
+        # TODO: might not need this any more.
+        self.main_hash_justified = True
+
+@private
+# TODO: find all place where this should be used instead.
+def finalize_epoch(e: num):
+    self.checkpoints[e].is_finalized = True
+    self.last_finalized_epoch = e
+    # TODO: `main_hash_finalized`?
+
+# Process a vote message
+# TODO: Rename to `submit_vote` and revise everything that calls it.
+@public
+def submit_vote(vote_msg: bytes <= 1024):
+    # TODO: RLP decoding only once.
+    validator_index, target_hash, target_epoch, source_epoch, _sig = self.extract_msg_from_vote(vote_msg)
+    self.check_valid_vote(validator_index, target_hash, target_epoch, source_epoch, sig)
+
+    cur_dyn_vote_amount = self.checkpoints[target_epoch].cur_dyn_vote_amount[source_epoch]
+    prev_dyn_vote_amount = self.checkpoints[target_epoch].prev_dyn_vote_amount[source_epoch]
+
+    # Keep track of vote and vote amount.
+    self.record_vote(validator_index, target_hash, target_epoch, source_epoch, sig,
+                     cur_dyn_vote_amount, prev_dyn_vote_amount)
+
+    # Process rewards if applicable.
+    timely = self.current_epoch == target_epoch
+    correct = self.expected_source_epoch == source_epoch
+    if timely and correct:
+        reward = floor(self.validators[validator_index].deposit * self.reward_factor) # TODO: Check correct reward factor is set.
         self.proc_reward(validator_index, reward)
-    # If enough votes with the same source_epoch and hash are made,
-    # then the hash value is justified
-    if (current_dynasty_votes >= self.total_curdyn_deposits * 2 / 3 and
-            previous_dynasty_votes >= self.total_prevdyn_deposits * 2 / 3) and \
-            not self.votes[target_epoch].is_justified:
-        self.votes[target_epoch].is_justified = True
-        self.last_justified_epoch = target_epoch
-        if target_epoch == self.current_epoch:
-            self.main_hash_justified = True
-        # If two epochs are justified consecutively,
-        # then the source_epoch finalized
+
+    # Check if we have enough amount of votes to justify the checkpoint.
+    cur_have_supermajority = cur_dyn_vote_amount >= self.total_curdyn_deposits * 2 / 3
+    prev_have_supermajority = prev_dyn_vote_amount >= self.total_prevdyn_deposits * 2 / 3
+    justified = self.checkpoints[target_epoch].is_justified
+    if cur_have_supermajority and prev_have_supermajority and not justified:
+        self.justify_epoch(target_epoch)
+        # If two epochs are justified consecutively, then the source_epoch finalized
         if target_epoch == source_epoch + 1:
-            self.votes[source_epoch].is_finalized = True
-            self.last_finalized_epoch = source_epoch
+            self.finalize_epoch(source_epoch)
     raw_log([self.vote_log_topic], vote_msg)
 
 # Cannot make two prepares in the same epoch; no surrond vote.

--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -431,9 +431,9 @@ def record_vote(validator_index: num,
     assert is_in_current_dynasty(validator_index) or is_in_prev_dynasty(validator_index)
 
     # Record that this vote took place
-    if is_in_current_dynasty(validator_index):
+    if is_in_current_dynasty:
         self.checkpoints[target_epoch].cur_dyn_vote_amount[source_epoch] += self.validators[validator_index].deposit
-    if is_in_prev_dynasty(validator_index):
+    if is_in_prev_dynasty:
         self.checkpoints[target_epoch].prev_dyn_vote_amount[source_epoch] += self.validators[validator_index].deposit
 
 # Process a vote message


### PR DESCRIPTION
https://github.com/ethereum/casper/issues/28

* Vote refactor
    * `extract_msg_from_vote()`: Message bytes to variables.
    * `check_valid_vote()`: Series of assert statements.
    * `record_vote()`: Increments the votes amount.
    * `justify_epoch()`
    * `finalize_epoch()`
    * @vbuterin helped simplify the `record_vote()` logic and remove `in_current_dynasty()` and `in_previous_dynasty()` helper methods 
* Rename `vote()` to `submit_vote()`
* Rename `votes` to `checkpoints`
* Rename current votes and previous votes to ...`vote_amount`
* Some comments and formatting.

[] What files currently call `vote()` in pyethereum? Other things that would break?