### PR TITLE
adds type definitions to simple_casper.v.py local variables

### DIFF
--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -195,7 +195,7 @@ def deposit_exists() -> bool:
 # TODO: Might want to split out the cases separately.
 @private
 def increment_dynasty():
-    epoch = self.current_epoch
+    epoch:num = self.current_epoch
     # Increment the dynasty if finalized
     if self.votes[epoch-2].is_finalized:
         self.dynasty += 1
@@ -212,25 +212,25 @@ def increment_dynasty():
 # Returns number of epochs since finalization.
 @private
 def get_esf() -> num:
-    epoch = self.current_epoch
+    epoch:num = self.current_epoch
     return epoch - self.last_finalized_epoch
 
 # Returns the current collective reward factor, which rewards the dynasty for high-voting levels.
 @private
 def get_collective_reward() -> decimal:
-    epoch = self.current_epoch
-    live = self.get_esf() <= 2
+    epoch:num = self.current_epoch
+    live:bool = self.get_esf() <= 2
     if not self.deposit_exists() or not live:
         return 0.0
     # Fraction that voted
-    cur_vote_frac = self.votes[epoch - 1].cur_dyn_votes[self.expected_source_epoch] / self.total_curdyn_deposits
-    prev_vote_frac = self.votes[epoch - 1].prev_dyn_votes[self.expected_source_epoch] / self.total_prevdyn_deposits
-    vote_frac = min(cur_vote_frac, prev_vote_frac)
+    cur_vote_frac:decimal = self.votes[epoch - 1].cur_dyn_votes[self.expected_source_epoch] / self.total_curdyn_deposits
+    prev_vote_frac:decimal = self.votes[epoch - 1].prev_dyn_votes[self.expected_source_epoch] / self.total_prevdyn_deposits
+    vote_frac:decimal = min(cur_vote_frac, prev_vote_frac)
     return vote_frac * self.reward_factor / 2
 
 @private
 def insta_finalize():
-    epoch = self.current_epoch
+    epoch:num = self.current_epoch
     self.main_hash_justified = True
     self.votes[epoch - 1].is_justified = True
     self.votes[epoch - 1].is_finalized = True
@@ -240,10 +240,10 @@ def insta_finalize():
 # Compute square root factor
 @private
 def get_sqrt_of_total_deposits() -> decimal:
-    epoch = self.current_epoch
-    ether_deposited_as_number = floor(max(self.total_prevdyn_deposits, self.total_curdyn_deposits) *
-                                      self.deposit_scale_factor[epoch - 1] / as_wei_value(1, ether)) + 1
-    sqrt = ether_deposited_as_number / 2.0
+    epoch:num = self.current_epoch
+    ether_deposited_as_number:num = floor(max(self.total_prevdyn_deposits, self.total_curdyn_deposits) *
+                                      self.deposit_scale_factor[epoch - 1] / as_wei_value(1, "ether")) + 1
+    sqrt:decimal = ether_deposited_as_number / 2.0
     for i in range(20):
         sqrt = (sqrt + (ether_deposited_as_number / sqrt)) / 2
     return sqrt
@@ -254,7 +254,7 @@ def get_sqrt_of_total_deposits() -> decimal:
 @public
 def initialize_epoch(epoch: num):
     # Check that the epoch actually has started
-    computed_current_epoch = block.number / self.epoch_length
+    computed_current_epoch:num = block.number / self.epoch_length
     assert epoch <= computed_current_epoch and epoch == self.current_epoch + 1
 
     # Setup
@@ -267,7 +267,7 @@ def initialize_epoch(epoch: num):
 
     if self.deposit_exists():
         # Set the reward factor for the next epoch.
-        adj_interest_base = self.base_interest_factor / self.get_sqrt_of_total_deposits()  # TODO: sqrt is based on previous epoch starting deposit
+        adj_interest_base:decimal = self.base_interest_factor / self.get_sqrt_of_total_deposits()  # TODO: sqrt is based on previous epoch starting deposit
         self.reward_factor = adj_interest_base + self.base_penalty_factor * self.get_esf()  # TODO: might not be bpf. clarify is positive?
         # ESF is only thing that is changing and reward_factor is being used above.
         assert self.reward_factor > 0
@@ -308,12 +308,12 @@ def logout(logout_msg: bytes <= 1024):
     assert self.current_epoch == block.number / self.epoch_length
     # Get hash for signature, and implicitly assert that it is an RLP list
     # consisting solely of RLP elements
-    sighash = extract32(raw_call(self.sighasher, logout_msg, gas=200000, outsize=32), 0)
+    sighash:bytes32 = extract32(raw_call(self.sighasher, logout_msg, gas=200000, outsize=32), 0)
     # Extract parameters
     values = RLPList(logout_msg, [num, num, bytes])
-    validator_index = values[0]
-    epoch = values[1]
-    sig = values[2]
+    validator_index:num = values[0]
+    epoch:num = values[1]
+    sig: bytes <= 1024 = values[2]
     assert self.current_epoch >= epoch
     # Signature check
     assert extract32(raw_call(self.validators[validator_index].addr, concat(sighash, sig), gas=500000, outsize=32), 0) == as_bytes32(1)
@@ -342,22 +342,22 @@ def delete_validator(validator_index: num):
 def withdraw(validator_index: num):
     # Check that we can withdraw
     assert self.dynasty >= self.validators[validator_index].end_dynasty + 1
-    end_epoch = self.dynasty_start_epoch[self.validators[validator_index].end_dynasty + 1]
+    end_epoch:num = self.dynasty_start_epoch[self.validators[validator_index].end_dynasty + 1]
     assert self.current_epoch >= end_epoch + self.withdrawal_delay
     # Withdraw
-    withdraw_amount = floor(self.validators[validator_index].deposit * self.deposit_scale_factor[end_epoch])
+    withdraw_amount:num(wei) = floor(self.validators[validator_index].deposit * self.deposit_scale_factor[end_epoch])
     send(self.validators[validator_index].withdrawal_addr, withdraw_amount)
     self.delete_validator(validator_index)
 
 # Reward the given validator & miner, and reflect this in total deposit figured
 @private
 def proc_reward(validator_index: num, reward: num(wei/m)):
-    start_epoch = self.dynasty_start_epoch[self.validators[validator_index].start_dynasty]
+    start_epoch:num = self.dynasty_start_epoch[self.validators[validator_index].start_dynasty]
     self.validators[validator_index].deposit += reward
-    start_dynasty = self.validators[validator_index].start_dynasty
-    end_dynasty = self.validators[validator_index].end_dynasty
-    current_dynasty = self.dynasty
-    past_dynasty = current_dynasty - 1
+    start_dynasty:num = self.validators[validator_index].start_dynasty
+    end_dynasty:num = self.validators[validator_index].end_dynasty
+    current_dynasty:num = self.dynasty
+    past_dynasty:num = current_dynasty - 1
     if ((start_dynasty <= current_dynasty) and (current_dynasty < end_dynasty)):
         self.total_curdyn_deposits += reward
     if ((start_dynasty <= past_dynasty) and (past_dynasty < end_dynasty)):
@@ -373,14 +373,14 @@ def proc_reward(validator_index: num, reward: num(wei/m)):
 def vote(vote_msg: bytes <= 1024):
     # Get hash for signature, and implicitly assert that it is an RLP list
     # consisting solely of RLP elements
-    sighash = extract32(raw_call(self.sighasher, vote_msg, gas=200000, outsize=32), 0)
+    sighash:bytes32 = extract32(raw_call(self.sighasher, vote_msg, gas=200000, outsize=32), 0)
     # Extract parameters
     values = RLPList(vote_msg, [num, bytes32, num, num, bytes])
-    validator_index = values[0]
-    target_hash = values[1]
-    target_epoch = values[2]
-    source_epoch = values[3]
-    sig = values[4]
+    validator_index:num = values[0]
+    target_hash:bytes32 = values[1]
+    target_epoch:num = values[2]
+    source_epoch:num = values[3]
+    sig: bytes <= 1024 = values[4]
     # Check the signature
     assert extract32(raw_call(self.validators[validator_index].addr, concat(sighash, sig), gas=500000, outsize=32), 0) == as_bytes32(1)
     # Check that this vote has not yet been made
@@ -393,22 +393,22 @@ def vote(vote_msg: bytes <= 1024):
     # Check that we are at least (epoch length / 4) blocks into the epoch
     # assert block.number % self.epoch_length >= self.epoch_length / 4
     # Original starting dynasty of the validator; fail if before
-    start_dynasty = self.validators[validator_index].start_dynasty
+    start_dynasty:num = self.validators[validator_index].start_dynasty
     # Ending dynasty of the current login period
-    end_dynasty = self.validators[validator_index].end_dynasty
+    end_dynasty:num = self.validators[validator_index].end_dynasty
     # Dynasty of the vote
-    current_dynasty = self.dynasty_in_epoch[target_epoch]
-    past_dynasty = current_dynasty - 1
-    in_current_dynasty = ((start_dynasty <= current_dynasty) and (current_dynasty < end_dynasty))
-    in_prev_dynasty = ((start_dynasty <= past_dynasty) and (past_dynasty < end_dynasty))
+    current_dynasty:num = self.dynasty_in_epoch[target_epoch]
+    past_dynasty:num = current_dynasty - 1
+    in_current_dynasty:bool = ((start_dynasty <= current_dynasty) and (current_dynasty < end_dynasty))
+    in_prev_dynasty:bool = ((start_dynasty <= past_dynasty) and (past_dynasty < end_dynasty))
     assert in_current_dynasty or in_prev_dynasty
     # Record that the validator voted for this target epoch so they can't again
     self.votes[target_epoch].vote_bitmap[target_hash][validator_index / 256] = \
         bitwise_or(self.votes[target_epoch].vote_bitmap[target_hash][validator_index / 256],
                    shift(as_num256(1), validator_index % 256))
     # Record that this vote took place
-    current_dynasty_votes = self.votes[target_epoch].cur_dyn_votes[source_epoch]
-    previous_dynasty_votes = self.votes[target_epoch].prev_dyn_votes[source_epoch]
+    current_dynasty_votes:decimal(wei/m) = self.votes[target_epoch].cur_dyn_votes[source_epoch]
+    previous_dynasty_votes:decimal(wei/m) = self.votes[target_epoch].prev_dyn_votes[source_epoch]
     if in_current_dynasty:
         current_dynasty_votes += self.validators[validator_index].deposit
         self.votes[target_epoch].cur_dyn_votes[source_epoch] = current_dynasty_votes
@@ -419,7 +419,7 @@ def vote(vote_msg: bytes <= 1024):
     # Check that we have not yet voted for this target_epoch
     # Pay the reward if the vote was submitted in time and the vote is voting the correct data
     if self.current_epoch == target_epoch and self.expected_source_epoch == source_epoch:
-        reward = floor(self.validators[validator_index].deposit * self.reward_factor)
+        reward:num(wei/m) = floor(self.validators[validator_index].deposit * self.reward_factor)
         self.proc_reward(validator_index, reward)
     # If enough votes with the same source_epoch and hash are made,
     # then the hash value is justified
@@ -441,21 +441,21 @@ def vote(vote_msg: bytes <= 1024):
 @public
 def slash(vote_msg_1: bytes <= 1024, vote_msg_2: bytes <= 1024):
     # Message 1: Extract parameters
-    sighash_1 = extract32(raw_call(self.sighasher, vote_msg_1, gas=200000, outsize=32), 0)
-    values = RLPList(vote_msg_1, [num, bytes32, num, num, bytes])
-    validator_index_1 = values[0]
-    target_epoch_1 = values[2]
-    source_epoch_1 = values[3]
-    sig_1 = values[4]
+    sighash_1:bytes32 = extract32(raw_call(self.sighasher, vote_msg_1, gas=200000, outsize=32), 0)
+    vote_1_values = RLPList(vote_msg_1, [num, bytes32, num, num, bytes])
+    validator_index_1:num = vote_1_values[0]
+    target_epoch_1:num = vote_1_values[2]
+    source_epoch_1:num = vote_1_values[3]
+    sig_1: bytes <= 1024 = vote_1_values[4]
     # Check the signature for vote message 1
     assert extract32(raw_call(self.validators[validator_index_1].addr, concat(sighash_1, sig_1), gas=500000, outsize=32), 0) == as_bytes32(1)
     # Message 2: Extract parameters
-    sighash_2 = extract32(raw_call(self.sighasher, vote_msg_2, gas=200000, outsize=32), 0)
-    values = RLPList(vote_msg_2, [num, bytes32, num, num, bytes])
-    validator_index_2 = values[0]
-    target_epoch_2 = values[2]
-    source_epoch_2 = values[3]
-    sig_2 = values[4]
+    sighash_2:bytes32 = extract32(raw_call(self.sighasher, vote_msg_2, gas=200000, outsize=32), 0)
+    vote_2_values = RLPList(vote_msg_2, [num, bytes32, num, num, bytes])
+    validator_index_2:num = vote_2_values[0]
+    target_epoch_2:num = vote_2_values[2]
+    source_epoch_2:num = vote_2_values[3]
+    sig_2: bytes <= 1024 = vote_2_values[4]
     # Check the signature for vote message 2
     assert extract32(raw_call(self.validators[validator_index_2].addr, concat(sighash_2, sig_2), gas=500000, outsize=32), 0) == as_bytes32(1)
     # Check the messages are from the same validator
@@ -463,7 +463,7 @@ def slash(vote_msg_1: bytes <= 1024, vote_msg_2: bytes <= 1024):
     # Check the messages are not the same
     assert sighash_1 != sighash_2
     # Detect slashing
-    slashing_condition_detected = False
+    slashing_condition_detected:bool = False
     if target_epoch_1 == target_epoch_2:
         # NO DBL VOTE
         slashing_condition_detected = True
@@ -473,8 +473,8 @@ def slash(vote_msg_1: bytes <= 1024, vote_msg_2: bytes <= 1024):
         slashing_condition_detected = True
     assert slashing_condition_detected
     # Delete the offending validator, and give a 4% "finder's fee"
-    validator_deposit = self.get_deposit_size(validator_index_1)
-    slashing_bounty = validator_deposit / 25
+    validator_deposit:wei_value = self.get_deposit_size(validator_index_1)
+    slashing_bounty:wei_value = validator_deposit / 25
     self.total_destroyed += validator_deposit * 24 / 25
     self.delete_validator(validator_index_1)
     send(msg.sender, slashing_bounty)


### PR DESCRIPTION
While playing around with Casper, I found that the file `simple_casper.v.py` didn't compile with the latest version of vyper (which is so cool by the way!). I went through and added all the necessary type definitions, which was the majority of the compilation errors. There was one other case where there was an error from a duplicate variable name declaration.