### PR TITLE
Fix tester allocations in testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,12 +108,8 @@ def casper_config():
 
 
 @pytest.fixture
-def test_chain(alloc={}, genesis_gas_limit=9999999, min_gas_limit=5000, startgas=3141592):
-    # alloc
-    alloc[tester.a0] = {'balance': 100000 * utils.denoms.ether}
-
-    for i in range(9):
-        alloc[utils.int_to_addr(i)] = {'balance': 1}
+def test_chain(alloc=tester.base_alloc, genesis_gas_limit=9999999,
+               min_gas_limit=5000, startgas=3141592):
     # genesis
     header = {
         "number": 0, "gas_limit": genesis_gas_limit,


### PR DESCRIPTION
# Issue 
Tester allocation to accounts a1 -> a9 did not actually have any ether in them. 

Unfortunately the accounts were still able to send ether to contracts via `tester.ABIContract`. I think this is due to a bug in `tester.ABIContract`. Even after a call to a payable method on an ABIContract, the `value` sent to the contract is not deducted from the account. Ether made from thin air (ONLY IN TESTING).

Will investigate further on the ABIContract bug and create an issue where need-be.

# How was it resolved
Utilize default allocation of funds in the `test_chain` pytest fixture.