### PR TITLE
fix mismatched hash/epoch exploit

### DIFF
--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -401,12 +401,11 @@ def vote(vote_msg: bytes <= 1024):
     # Check that this vote has not yet been made
     assert not bitwise_and(self.votes[target_epoch].vote_bitmap[target_hash][validator_index / 256],
                            shift(as_num256(1), validator_index % 256))
-    # Check that the vote's target hash is correct
+    # Check that the vote's target epoch and hash are correct
     assert target_hash == self.get_recommended_target_hash()
+    assert target_epoch == self.current_epoch
     # Check that the vote source points to a justified epoch
     assert self.votes[source_epoch].is_justified
-    # Check that we are at least (epoch length / 4) blocks into the epoch
-    # assert block.number % self.epoch_length >= self.epoch_length / 4
     # Original starting dynasty of the validator; fail if before
     start_dynasty: num = self.validators[validator_index].start_dynasty
     # Ending dynasty of the current login period
@@ -431,9 +430,8 @@ def vote(vote_msg: bytes <= 1024):
         previous_dynasty_votes += self.validators[validator_index].deposit
         self.votes[target_epoch].prev_dyn_votes[source_epoch] = previous_dynasty_votes
     # Process rewards.
-    # Check that we have not yet voted for this target_epoch
     # Pay the reward if the vote was submitted in time and the vote is voting the correct data
-    if self.current_epoch == target_epoch and self.expected_source_epoch == source_epoch:
+    if self.expected_source_epoch == source_epoch:
         reward: num(wei/m) = floor(self.validators[validator_index].deposit * self.reward_factor)
         self.proc_reward(validator_index, reward)
     # If enough votes with the same source_epoch and hash are made,

--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -441,11 +441,11 @@ def vote(vote_msg: bytes <= 1024):
             not self.votes[target_epoch].is_justified:
         self.votes[target_epoch].is_justified = True
         self.last_justified_epoch = target_epoch
+        self.main_hash_justified = True
+
         # Log target epoch status update
         log.Epoch(target_epoch, self.checkpoint_hashes[target_epoch], True, False)
 
-        if target_epoch == self.current_epoch:
-            self.main_hash_justified = True
         # If two epochs are justified consecutively,
         # then the source_epoch finalized
         if target_epoch == source_epoch + 1:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def base_sender_privkey():
     return tester.k0
 
 
-@pytest.fixture(params=FUNDED_PRIVKEYS[0:3])
+@pytest.fixture(params=FUNDED_PRIVKEYS[0:1])
 def funded_privkey(request):
     return request.param
 


### PR DESCRIPTION
Addresses #57 

# Implementation
- Exploit was confirmed via red-test
- Exploit was fixed adding additional assert
- Conditional upon `target_hash` being `current_epoch` for reward was removed because already asserted at beginning of function.