### PR TITLE
[chore] Comments udpates and variables renames

### DIFF
--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -262,9 +262,8 @@ def initialize_epoch(epoch: int128):
     # Setup
     self.current_epoch = epoch
 
-    # Reward if finalized at least in the last two epochs
-    self.last_nonvoter_rescale = (1 + self.collective_reward()) /(1 + self.reward_factor)
-    self.last_voter_rescale = self.last_nonvoter_rescale * (1 + self.reward_factor)
+    self.last_voter_rescale = 1 + self.collective_reward()
+    self.last_nonvoter_rescale = self.last_voter_rescale / (1 + self.reward_factor)
     self.deposit_scale_factor[epoch] = self.deposit_scale_factor[epoch - 1] * self.last_nonvoter_rescale
 
     if self.deposit_exists():

--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -168,12 +168,12 @@ def deposit_size(validator_index: int128) -> int128(wei):
 
 @public
 @constant
-def get_total_curdyn_deposits() -> wei_value:
+def total_curdyn_deposits_scaled() -> wei_value:
     return floor(self.total_curdyn_deposits * self.deposit_scale_factor[self.current_epoch])
 
 @public
 @constant
-def get_total_prevdyn_deposits() -> wei_value:
+def total_prevdyn_deposits_scaled() -> wei_value:
     return floor(self.total_prevdyn_deposits * self.deposit_scale_factor[self.current_epoch])
 
 # Helper functions that clients can call to know what to vote

--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -363,7 +363,6 @@ def withdraw(validator_index: int128):
 # Reward the given validator & miner, and reflect this in total deposit figured
 @private
 def proc_reward(validator_index: int128, reward: int128(wei/m)):
-    start_epoch: int128 = self.dynasty_start_epoch[self.validators[validator_index].start_dynasty]
     self.validators[validator_index].deposit += reward
     start_dynasty: int128 = self.validators[validator_index].start_dynasty
     end_dynasty: int128 = self.validators[validator_index].end_dynasty

--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -28,7 +28,7 @@ validators: public({
 checkpoint_hashes: public(bytes32[int128])
 
 # Number of validators
-nextValidatorIndex: public(int128)
+next_validator_index: public(int128)
 
 # Mapping of validator's signature address to their index number
 validator_indexes: public(int128[address])
@@ -136,7 +136,7 @@ def __init__(
     self.purity_checker = _purity_checker
 
     # Start validator index counter at 1 because validator_indexes[] requires non-zero values
-    self.nextValidatorIndex = 1
+    self.next_validator_index = 1
 
     self.deposit_scale_factor[0] = 10000000000.0
     self.dynasty = 0
@@ -285,15 +285,15 @@ def deposit(validation_addr: address, withdrawal_addr: address):
     assert msg.value >= self.min_deposit_size
     start_dynasty: int128 = self.dynasty + 2
     scaled_deposit: decimal(wei/m) = msg.value / self.deposit_scale_factor[self.current_epoch]
-    self.validators[self.nextValidatorIndex] = {
+    self.validators[self.next_validator_index] = {
         deposit: scaled_deposit,
         start_dynasty: start_dynasty,
         end_dynasty: self.default_end_dynasty,
         addr: validation_addr,
         withdrawal_addr: withdrawal_addr
     }
-    self.validator_indexes[withdrawal_addr] = self.nextValidatorIndex
-    self.nextValidatorIndex += 1
+    self.validator_indexes[withdrawal_addr] = self.next_validator_index
+    self.next_validator_index += 1
     self.dynasty_wei_delta[start_dynasty] += scaled_deposit
     # Log deposit event
     log.Deposit(withdrawal_addr, self.validator_indexes[withdrawal_addr], validation_addr, self.validators[self.validator_indexes[withdrawal_addr]].start_dynasty, msg.value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -372,7 +372,7 @@ def induct_validator(casper_chain, casper, deposit_validator, new_epoch):
 @pytest.fixture
 def induct_validators(casper_chain, casper, deposit_validator, new_epoch):
     def induct_validators(privkeys, values):
-        start_index = casper.nextValidatorIndex()
+        start_index = casper.next_validator_index()
         if casper.current_epoch() == 0:
             new_epoch()
         for privkey, value in zip(privkeys, values):

--- a/tests/test_chain_initialization.py
+++ b/tests/test_chain_initialization.py
@@ -36,10 +36,10 @@ def test_sig_hasher_is_pure(
 # sanity check on casper contract basic functionality
 def test_init_first_epoch(casper, new_epoch):
     assert casper.current_epoch() == 0
-    assert casper.nextValidatorIndex() == 1
+    assert casper.next_validator_index() == 1
 
     new_epoch()
 
     assert casper.dynasty() == 0
-    assert casper.nextValidatorIndex() == 1
+    assert casper.next_validator_index() == 1
     assert casper.current_epoch() == 1

--- a/tests/test_deposit.py
+++ b/tests/test_deposit.py
@@ -21,10 +21,10 @@ def test_deposit_sets_validator_deposit(casper, funded_privkey, deposit_amount,
 
 def test_deposit_updates_next_val_index(casper, funded_privkey, deposit_amount,
                                         deposit_validator):
-    next_validator_index = casper.nextValidatorIndex()
+    next_validator_index = casper.next_validator_index()
     validator_index = deposit_validator(funded_privkey, deposit_amount)
     assert validator_index == next_validator_index
-    assert casper.nextValidatorIndex() == next_validator_index + 1
+    assert casper.next_validator_index() == next_validator_index + 1
 
 
 def test_deposit_sets_start_dynasty(casper, funded_privkey, deposit_amount,

--- a/tests/test_deposit.py
+++ b/tests/test_deposit.py
@@ -56,20 +56,20 @@ def test_deposit_updates_dynasty_wei_delta(casper, funded_privkey, deposit_amoun
 
 def test_deposit_updates_total_deposits(casper, funded_privkey, deposit_amount,
                                         induct_validator, mk_suggested_vote, new_epoch):
-    assert casper.get_total_curdyn_deposits() == 0
-    assert casper.get_total_prevdyn_deposits() == 0
+    assert casper.total_curdyn_deposits_scaled() == 0
+    assert casper.total_prevdyn_deposits_scaled() == 0
 
     # note, full induction
     validator_index = induct_validator(funded_privkey, deposit_amount)
 
-    assert casper.get_total_curdyn_deposits() == deposit_amount
-    assert casper.get_total_prevdyn_deposits() == 0
+    assert casper.total_curdyn_deposits_scaled() == deposit_amount
+    assert casper.total_prevdyn_deposits_scaled() == 0
 
     casper.vote(mk_suggested_vote(validator_index, funded_privkey))
     new_epoch()
 
-    assert casper.get_total_curdyn_deposits() == deposit_amount
-    assert casper.get_total_prevdyn_deposits() == deposit_amount
+    assert casper.total_curdyn_deposits_scaled() == deposit_amount
+    assert casper.total_prevdyn_deposits_scaled() == deposit_amount
 
 
 

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -30,7 +30,7 @@ def test_logout_with_multiple_validators(casper, funded_privkeys,
                                          mk_suggested_vote, logout_validator):
     validator_indexes = induct_validators(funded_privkeys, [deposit_amount] * len(funded_privkeys))
     num_validators = len(validator_indexes)
-    assert casper.get_total_curdyn_deposits() == deposit_amount * len(funded_privkeys)
+    assert casper.total_curdyn_deposits_scaled() == deposit_amount * len(funded_privkeys)
 
     # finalize 3 epochs to get to a stable state
     for _ in range(3):
@@ -59,8 +59,8 @@ def test_logout_with_multiple_validators(casper, funded_privkeys,
     logging_out_deposit_size = casper.deposit_size(logged_out_index)
     total_deposit_size = logged_in_deposit_size + logging_out_deposit_size
 
-    assert abs(logged_in_deposit_size - casper.get_total_curdyn_deposits()) < num_validators
-    assert abs(total_deposit_size - casper.get_total_prevdyn_deposits()) < num_validators
+    assert abs(logged_in_deposit_size - casper.total_curdyn_deposits_scaled()) < num_validators
+    assert abs(total_deposit_size - casper.total_prevdyn_deposits_scaled()) < num_validators
 
     # validator no longer in prev or cur dyn
     for i, validator_index in enumerate(logged_in_indexes):
@@ -69,8 +69,8 @@ def test_logout_with_multiple_validators(casper, funded_privkeys,
 
     logged_in_deposit_size = sum(map(casper.deposit_size, logged_in_indexes))
 
-    assert abs(logged_in_deposit_size - casper.get_total_curdyn_deposits()) < num_validators
-    assert abs(logged_in_deposit_size - casper.get_total_prevdyn_deposits()) < num_validators
+    assert abs(logged_in_deposit_size - casper.total_curdyn_deposits_scaled()) < num_validators
+    assert abs(logged_in_deposit_size - casper.total_prevdyn_deposits_scaled()) < num_validators
 
     # validator can withdraw after delay
     for i in range(casper.withdrawal_delay()):

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -5,9 +5,9 @@ def test_logs(casper, funded_privkey, new_epoch, get_logs, deposit_validator,
               mk_suggested_vote, get_last_log, casper_chain, logout_validator):
     new_epoch()
     assert casper.current_epoch() == 1
-    assert casper.nextValidatorIndex() == 1
+    assert casper.next_validator_index() == 1
 
-    validator_index = casper.nextValidatorIndex()
+    validator_index = casper.next_validator_index()
     deposit_validator(funded_privkey, 1900 * 10**18)
     # Deposit log
     log1 = get_last_log(casper_chain, casper)

--- a/tests/test_slashing.py
+++ b/tests/test_slashing.py
@@ -4,7 +4,7 @@ from ethereum import utils
 def test_slash_no_dbl_prepare(casper, funded_privkey, deposit_amount, get_last_log,
                               induct_validator, mk_vote, fake_hash, casper_chain):
     validator_index = induct_validator(funded_privkey, deposit_amount)
-    assert casper.get_total_curdyn_deposits() == deposit_amount
+    assert casper.total_curdyn_deposits_scaled() == deposit_amount
 
     vote_1 = mk_vote(
         validator_index,
@@ -41,7 +41,7 @@ def test_slash_no_dbl_prepare(casper, funded_privkey, deposit_amount, get_last_l
 def test_slash_no_surround(casper, funded_privkey, deposit_amount, new_epoch,
                            induct_validator, mk_vote, fake_hash, assert_tx_failed):
     validator_index = induct_validator(funded_privkey, deposit_amount)
-    assert casper.get_total_curdyn_deposits() == deposit_amount
+    assert casper.total_curdyn_deposits_scaled() == deposit_amount
 
     vote_1 = mk_vote(
         validator_index,

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -36,14 +36,14 @@ def test_deposit(casper_chain, casper, privkey, amount,
         new_epoch()
 
     assert casper.dynasty() == 2
-    assert casper.get_total_curdyn_deposits() == amount
-    assert casper.get_total_prevdyn_deposits() == 0
+    assert casper.total_curdyn_deposits_scaled() == amount
+    assert casper.total_prevdyn_deposits_scaled() == 0
 
 
 def test_vote_single_validator(casper, funded_privkey, deposit_amount,
                                new_epoch, induct_validator, mk_suggested_vote):
     validator_index = induct_validator(funded_privkey, deposit_amount)
-    assert casper.get_total_curdyn_deposits() == deposit_amount
+    assert casper.total_curdyn_deposits_scaled() == deposit_amount
 
     prev_dynasty = casper.dynasty()
     for i in range(10):
@@ -58,7 +58,7 @@ def test_vote_single_validator(casper, funded_privkey, deposit_amount,
 def test_vote_target_epoch_twice(casper, funded_privkey, deposit_amount, new_epoch,
                                  induct_validator, mk_suggested_vote, assert_tx_failed):
     validator_index = induct_validator(funded_privkey, deposit_amount)
-    assert casper.get_total_curdyn_deposits() == deposit_amount
+    assert casper.total_curdyn_deposits_scaled() == deposit_amount
 
     casper.vote(mk_suggested_vote(validator_index, funded_privkey))
     # second vote on same target epoch fails
@@ -68,7 +68,7 @@ def test_vote_target_epoch_twice(casper, funded_privkey, deposit_amount, new_epo
 def test_non_finalization_loss(casper, funded_privkey, deposit_amount, new_epoch,
                                induct_validator, mk_suggested_vote, assert_tx_failed):
     validator_index = induct_validator(funded_privkey, deposit_amount)
-    assert casper.get_total_curdyn_deposits() == deposit_amount
+    assert casper.total_curdyn_deposits_scaled() == deposit_amount
 
     casper.vote(mk_suggested_vote(validator_index, funded_privkey))
     new_epoch()
@@ -86,7 +86,7 @@ def test_non_finalization_loss(casper, funded_privkey, deposit_amount, new_epoch
 def test_mismatched_epoch_and_hash(casper, funded_privkey, deposit_amount,
                                    induct_validator, mk_vote, new_epoch, assert_tx_failed):
     validator_index = induct_validator(funded_privkey, deposit_amount)
-    assert casper.get_total_curdyn_deposits() == deposit_amount
+    assert casper.total_curdyn_deposits_scaled() == deposit_amount
 
     # step forward one epoch to ensure that validator is allowed
     # to vote on (current_epoch - 1)
@@ -111,7 +111,7 @@ def test_consensus_after_non_finalization_streak(casper, funded_privkey, deposit
                                                  induct_validator, mk_suggested_vote,
                                                  assert_tx_failed):
     validator_index = induct_validator(funded_privkey, deposit_amount)
-    assert casper.get_total_curdyn_deposits() == deposit_amount
+    assert casper.total_curdyn_deposits_scaled() == deposit_amount
 
     # finalize an epoch as a base to the test
     casper.vote(mk_suggested_vote(validator_index, funded_privkey))

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -20,7 +20,7 @@ def test_deposit(casper_chain, casper, privkey, amount,
                  success, deposit_validator, new_epoch, assert_tx_failed):
     new_epoch()
     assert casper.current_epoch() == 1
-    assert casper.nextValidatorIndex() == 1
+    assert casper.next_validator_index() == 1
 
     if not success:
         assert_tx_failed(lambda: deposit_validator(privkey, amount))
@@ -28,7 +28,7 @@ def test_deposit(casper_chain, casper, privkey, amount,
 
     deposit_validator(privkey, amount)
 
-    assert casper.nextValidatorIndex() == 2
+    assert casper.next_validator_index() == 2
     assert casper.validator_indexes(utils.privtoaddr(privkey)) == 1
     assert casper.deposit_size(1) == amount
 


### PR DESCRIPTION
this is some minor fixes after reviewing recent issues, discussions, Casper economics, and contracts.

* Removed comments more helpful.
* reorder global variables
* `last_voter_rescale` was originally designed for debugging purpose and thus unused. Now it is used for making changes in `deposit_scale_factor ` more straightforward.
* rename `next_validator_index`
* rename `get_total_*dyn_deposits`
