### PR TITLE
Use more explicit byte representation for function call

### DIFF
--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -295,7 +295,7 @@ def initialize_epoch(epoch: int128):
 @payable
 def deposit(validation_addr: address, withdrawal_addr: address):
     assert self.current_epoch == floor(block.number / self.EPOCH_LENGTH)
-    assert extract32(raw_call(self.PURITY_CHECKER, concat('\xa1\x90>\xab', convert(validation_addr, 'bytes32')), gas=500000, outsize=32), 0) != convert(0, 'bytes32')
+    assert extract32(raw_call(self.PURITY_CHECKER, concat('\xa1\x90\x3e\xab', convert(validation_addr, 'bytes32')), gas=500000, outsize=32), 0) != convert(0, 'bytes32')
     assert not self.validator_indexes[withdrawal_addr]
     assert msg.value >= self.MIN_DEPOSIT_SIZE
     start_dynasty: int128 = self.dynasty + 2


### PR DESCRIPTION
Addresses #94.

Not a bug but it is clearer to have a sequence of bytes rather than relying on the ASCII encoding of `>`.

It is possible some tooling in the future won't parse vyper code in the same way as the current python stack does which introduces some room for error; this is an argument in favor of merging this PR now.