### PR TITLE
Update comment for `validator_indexes`

### DIFF
--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -30,7 +30,7 @@ checkpoint_hashes: public(bytes32[int128])
 # Number of validators
 next_validator_index: public(int128)
 
-# Mapping of validator's signature address to their index number
+# Mapping of validator's withdrawal address to their index number
 validator_indexes: public(int128[address])
 
 # Current dynasty, it measures the number of finalized checkpoints 


### PR DESCRIPTION
Closes #102.

The `validator_indexes` data tracks the withdrawal address instead of the signature address. So this PR just updates the comment in the contract to reflect that.