### PR TITLE
Expose the MIN_DEPOSIT_SIZE var

### DIFF
--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -111,8 +111,8 @@ PURITY_CHECKER: address
 BASE_INTEREST_FACTOR: public(decimal)
 BASE_PENALTY_FACTOR: public(decimal)
 
-# Minimum deposit size if no one else is validating
-MIN_DEPOSIT_SIZE: wei_value
+# Minimum deposit size required for a validator
+MIN_DEPOSIT_SIZE: public(wei_value)
 
 # Huge integer to be used for default end_dynasty for new validator
 DEFAULT_END_DYNASTY: int128


### PR DESCRIPTION
Publicly expose the MIN_DEPOSIT_SIZE variable required for validators. Can be handy to get this directly from the Casper contract.