### PR TITLE
Fixed issue with incorrect deposit_scale_factor causing Casper to stall

### DIFF
--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -140,9 +140,10 @@ def __init__(
     # Start validator index counter at 1 because validator_indexes[] requires non-zero values
     self.next_validator_index = 1
 
-    self.deposit_scale_factor[0] = 10000000000.0
     self.dynasty = 0
     self.current_epoch = floor(block.number / self.EPOCH_LENGTH)
+    # TODO: test deposit_scale_factor when deploying when current_epoch > 0
+    self.deposit_scale_factor[self.current_epoch] = 10000000000.0
     self.total_curdyn_deposits = 0
     self.total_prevdyn_deposits = 0
     self.DEFAULT_END_DYNASTY = 1000000000000000000000000000000


### PR DESCRIPTION
Addresses issue: https://github.com/ethereum/casper/issues/106

Fixes issue with Casper stalling due to incorrect deposit_scale_factor if deployed on a network that has been running for a while, such as mainnet.