### PR TITLE
Reduce validation gas limit

### DIFF
--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -264,7 +264,6 @@ def validate_signature(sighash: bytes32, sig: bytes <= 1024, validator_index: in
     return extract32(raw_call(self.validators[validator_index].addr, concat(sighash, sig), gas=self.VALIDATION_GAS_LIMIT, outsize=32), 0) == convert(1, 'bytes32')
 
 
-
 # ***** Public *****
 
 # Called at the start of any epoch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -414,10 +414,10 @@ def deposit_validator(casper_chain, casper, validation_addr):
 #       manually finalize
 @pytest.fixture
 def induct_validator(casper_chain, casper, deposit_validator, new_epoch):
-    def induct_validator(privkey, value):
+    def induct_validator(privkey, value, valcode_type="pure_ecrecover"):
         if casper.current_epoch() == 0:
             new_epoch()
-        validator_index = deposit_validator(privkey, value)
+        validator_index = deposit_validator(privkey, value, valcode_type)
         new_epoch()
         new_epoch()
         return validator_index

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -65,6 +65,31 @@ def test_vote_target_epoch_twice(casper, funded_privkey, deposit_amount, new_epo
     assert_tx_failed(lambda: casper.vote(mk_suggested_vote(validator_index, funded_privkey)))
 
 
+@pytest.mark.parametrize(
+    'valcode_type,success',
+    [
+        ('pure_greater_than_200k_gas', False),
+        ('pure_between_100k-200k_gas', True),
+    ]
+)
+def test_vote_validate_signature_gas_limit(valcode_type, success,
+                                           casper, funded_privkey, deposit_amount,
+                                           induct_validator, mk_suggested_vote,
+                                           assert_tx_failed):
+    validator_index = induct_validator(
+        funded_privkey,
+        deposit_amount,
+        valcode_type
+    )
+    assert casper.total_curdyn_deposits_scaled() == deposit_amount
+
+    if not success:
+        assert_tx_failed(lambda: casper.vote(mk_suggested_vote(validator_index, funded_privkey)))
+        return
+
+    casper.vote(mk_suggested_vote(validator_index, funded_privkey))
+
+
 def test_non_finalization_loss(casper, funded_privkey, deposit_amount, new_epoch,
                                induct_validator, mk_suggested_vote, assert_tx_failed):
     validator_index = induct_validator(funded_privkey, deposit_amount)

--- a/tests/utils/valcodes.py
+++ b/tests/utils/valcodes.py
@@ -7,6 +7,10 @@ from ethereum.utils import bytes_to_int
 PURE_OPCODE_HEX = 0x59
 PURE_EXPRESSION_LLL = ['msize']
 
+# Expensive opcode for testing gas limits
+ECRECOVER_LLL = ['call', 3000, 1, 0, 0, 128, 0, 32]
+ECRECOVER_GASCOST = 3000
+
 
 def generate_pure_ecrecover_LLL_source(address):
     return [
@@ -109,6 +113,10 @@ def generate_all_valcodes(address):
             address, PURE_EXPRESSION_LLL),
         'pure_bytecode_as_control': format_ecrecover_bytecode(
             address, PURE_OPCODE_HEX),
+        'pure_greater_than_200k_gas': format_LLL_source(
+            address, ['seq'] + [ECRECOVER_LLL] * int(2e5 / ECRECOVER_GASCOST)),
+        'pure_between_100k-200k_gas': format_LLL_source(
+            address, ['seq'] + [ECRECOVER_LLL] * int(1e5 / ECRECOVER_GASCOST)),
         **generate_impure_opcodes_as_LLL_source(address),
         **generate_unused_opcodes_as_evm_bytecode(address),
     }


### PR DESCRIPTION
Addresses #103 

- [x] add VARs for magic numbers
- [x] reduce val gas limit from 500k to 200k
- [x] add gas exceeded failure tests after https://github.com/ethereum/casper/pull/109 merged
- [x] add `validate_signature` private method

## questions
I'm considering adding private method `validate_signature(hash, sig, val_index) -> bool` to replace all of the calls like 
```python
assert extract32(raw_call(self.validators[validator_index].addr, concat(sighash, sig), gas=self.VALIDATION_GAS_LIMIT, outsize=32), 0) == convert(1, 'bytes32')
```

with 
```python
assert validate_signature(sighash, sig, validator_index)
```