### PR TITLE
Add resource links to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Resources
 
 - [EIP-1011](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1011.md):
-specifcation of the Casper the Friendly Finality Gadget (FFG) PoW/PoS consensus model.
+specification of the Casper the Friendly Finality Gadget (FFG) PoW/PoS consensus model.
 - [VALIDATOR_GUIDE.md](https://github.com/ethereum/casper/blob/master/VALIDATOR_GUIDE.md):
 information about implementing a Casper FFG validator.
 - [Casper the Friendly Finality Gadget](https://arxiv.org/abs/1710.09437): 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 [![Build Status](https://travis-ci.org/ethereum/casper.svg?branch=master)](https://travis-ci.org/ethereum/casper)
 
-See [EIP-1011](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1011.md)
-for a specifcation of the Casper the Friendly Finality Gadget PoW/PoS consensus model.
+## Resources
 
-See [VALIDATOR_GUIDE.md](https://github.com/ethereum/casper/blob/master/VALIDATOR_GUIDE.md)
-for information about implementing a Casper FFG validator.
+- [EIP-1011](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1011.md):
+specifcation of the Casper the Friendly Finality Gadget (FFG) PoW/PoS consensus model.
+- [VALIDATOR_GUIDE.md](https://github.com/ethereum/casper/blob/master/VALIDATOR_GUIDE.md):
+information about implementing a Casper FFG validator.
+- [Casper the Friendly Finality Gadget](https://arxiv.org/abs/1710.09437): 
+  paper by Vitalik Buterin and Virgil Griffith introducing Casper FFG.
 
 ## Casper Contract
 Implements [Casper FFG](https://arxiv.org/abs/1710.09437), written in [Vyper](https://github.com/ethereum/vyper).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 [![Build Status](https://travis-ci.org/ethereum/casper.svg?branch=master)](https://travis-ci.org/ethereum/casper)
 
+See [EIP-1011](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1011.md)
+for a specifcation of the Casper the Friendly Finality Gadget PoW/PoS consensus model.
+
+See [VALIDATOR_GUIDE.md](https://github.com/ethereum/casper/blob/master/VALIDATOR_GUIDE.md)
+for information about implementing a Casper FFG validator.
+
 ## Casper Contract
 Implements [Casper FFG](https://arxiv.org/abs/1710.09437), written in [Vyper](https://github.com/ethereum/vyper).
 


### PR DESCRIPTION
Hey,
  I found myself having some difficulty finding the validators guide again, so I thought it'd be nice if there were some links in the `README.md` to it, the EIP and the FFG paper.

Let me know your thoughts. Happy to take feedback, do iterations, etc.

:smile: 