### PR TITLE
Add explicit testing for initialize_epoch()

### DIFF
--- a/tests/test_initialize_epoch.py
+++ b/tests/test_initialize_epoch.py
@@ -34,12 +34,10 @@ def test_early_epoch_initialization(casper_chain, casper, new_epoch, assert_tx_f
 
 
 def test_double_epoch_initialization(casper_chain, casper, new_epoch, assert_tx_failed):
-    epoch_length = casper.EPOCH_LENGTH()
-
     new_epoch()
     initial_epoch = casper.current_epoch()
 
-    casper_chain.mine(epoch_length)
+    casper_chain.mine(casper.EPOCH_LENGTH())
 
     next_epoch = initial_epoch + 1
     casper.initialize_epoch(next_epoch)
@@ -65,12 +63,10 @@ def test_epoch_initialization_one_block_late(casper_chain, casper, new_epoch):
 
 
 def test_epoch_initialize_one_epoch_late(casper_chain, casper, new_epoch, assert_tx_failed):
-    epoch_length = casper.EPOCH_LENGTH()
-
     new_epoch()
     initial_epoch = casper.current_epoch()
 
-    casper_chain.mine(epoch_length * 2)
+    casper_chain.mine(casper.EPOCH_LENGTH() * 2)
     assert_tx_failed(
         lambda: casper.initialize_epoch(initial_epoch + 2)
     )

--- a/tests/test_initialize_epoch.py
+++ b/tests/test_initialize_epoch.py
@@ -14,7 +14,7 @@ def test_new_epoch_fixture(casper_chain, casper, new_epoch):
         assert (block_number % epoch_length) == 0
 
 
-def test_early_epoch_initialization(casper_chain, casper, new_epoch, assert_tx_failed):
+def test_epoch_length_range(casper_chain, casper, new_epoch, assert_tx_failed):
     epoch_length = casper.EPOCH_LENGTH()
 
     new_epoch()

--- a/tests/test_initialize_epoch.py
+++ b/tests/test_initialize_epoch.py
@@ -19,7 +19,7 @@ def test_epoch_length_range(casper_chain, casper, new_epoch, assert_tx_failed):
 
     new_epoch()
 
-    for _ in range(0, epoch_length):
+    for _ in range(epoch_length * 3):   # check the entire range 3 times
         casper_chain.mine(1)
         block_number = casper_chain.head_state.block_number
         is_epoch_block = (block_number % epoch_length) == 0


### PR DESCRIPTION
As specified in #50, this pull request adds explicit testing for the `initialize_epoch()` method.

It provides test for the following:
- Early and on-time epoch init across the entire `EPOCH_LENGTH` range.
- Double init of the same epoch
- Init one block after an epoch block
- Init of two epochs when more than one `EPOCH_LENGTH` has passed since the last init.
- Cannot init an epoch unless the previous epoch has had init.

Looking forward to feedback :)