### PR TITLE
Remove constructor. Replace with explicit `init`

### DIFF
--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -88,6 +88,9 @@ expected_source_epoch: public(int128)
 # Running total of deposits slashed
 total_slashed: public(wei_value[int128])
 
+# Flag that only allows contract initialization to happen once
+initialized: bool
+
 # ***** Parameters *****
 
 # Length of an epoch in blocks
@@ -117,13 +120,20 @@ SLASH_FRACTION_MULTIPLIER: int128
 
 
 @public
-def init(
-        epoch_length: int128, withdrawal_delay: int128, dynasty_logout_delay: int128,
-        msg_hasher: address, purity_checker: address,
-        base_interest_factor: decimal, base_penalty_factor: decimal,
-        min_deposit_size: wei_value):
+def init(epoch_length: int128, withdrawal_delay: int128, dynasty_logout_delay: int128,
+         msg_hasher: address, purity_checker: address,
+         base_interest_factor: decimal, base_penalty_factor: decimal,
+         min_deposit_size: wei_value):
 
+    assert not self.initialized
     assert epoch_length > 0 and epoch_length < 256
+    assert withdrawal_delay >= 0
+    assert dynasty_logout_delay >= 2
+    assert base_interest_factor >= 0.0
+    assert base_penalty_factor >= 0.0
+    assert min_deposit_size > 0
+
+    self.initialized = True
 
     self.EPOCH_LENGTH = epoch_length
     self.WITHDRAWAL_DELAY = withdrawal_delay

--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -117,7 +117,7 @@ SLASH_FRACTION_MULTIPLIER: int128
 
 
 @public
-def __init__(
+def init(
         epoch_length: int128, withdrawal_delay: int128, dynasty_logout_delay: int128,
         msg_hasher: address, purity_checker: address,
         base_interest_factor: decimal, base_penalty_factor: decimal,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,7 +216,8 @@ def casper_chain(
         dependency_transactions,
         msg_hasher_address,
         purity_checker_address,
-        base_sender_privkey):
+        base_sender_privkey,
+        initialize_contract=True):
     init_transactions = []
     nonce = 0
     # Create transactions for instantiating RLP decoder, msg hasher and purity checker,
@@ -274,8 +275,9 @@ def casper_chain(
 
     test_chain.mine(1)
 
-    casper_contract = casper(test_chain, casper_abi, casper_address)
-    casper_contract.init(*casper_args)
+    if initialize_contract:
+        casper_contract = casper(test_chain, casper_abi, casper_address)
+        casper_contract.init(*casper_args)
 
     return test_chain
 
@@ -291,11 +293,11 @@ def deploy_casper_contract(
         msg_hasher_address,
         purity_checker_address,
         base_sender_privkey):
-    def deploy_casper_contract(contract_args):
+    def deploy_casper_contract(contract_args, initialize_contract=True):
         chain = casper_chain(
             test_chain, contract_args, casper_code, casper_abi, casper_ct, casper_address,
             dependency_transactions, msg_hasher_address, purity_checker_address,
-            base_sender_privkey
+            base_sender_privkey, initialize_contract
         )
         return casper(chain, casper_abi, casper_address)
     return deploy_casper_contract

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -480,13 +480,14 @@ def assert_failed():
 
 
 @pytest.fixture
-def assert_tx_failed(casper_chain):
+def assert_tx_failed(test_chain):
     def assert_tx_failed(function_to_test, exception=tester.TransactionFailed):
-        initial_state = casper_chain.snapshot()
+        initial_state = test_chain.snapshot()
         with pytest.raises(exception):
             function_to_test()
-        casper_chain.revert(initial_state)
+        test_chain.revert(initial_state)
     return assert_tx_failed
+
 
 @pytest.fixture
 def get_logs():
@@ -503,6 +504,7 @@ def get_logs():
         # Return all events decoded in the receipt
         return [contract.translator.decode_event(log.topics, log.data) for log in logs]
     return get_logs
+
 
 @pytest.fixture
 def get_last_log(get_logs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,7 +210,9 @@ def casper_chain(
         test_chain,
         casper_args,
         casper_code,
+        casper_abi,
         casper_ct,
+        casper_address,
         dependency_transactions,
         msg_hasher_address,
         purity_checker_address,
@@ -243,9 +245,9 @@ def casper_chain(
     # otherwise, vyper compiler cannot properly embed RLP decoder address
     casper_bytecode = compiler.compile(casper_code)
 
-    init_args = casper_ct.encode_constructor_arguments(casper_args)
+    # init_args = casper_ct.encode_constructor_arguments(casper_args)
 
-    deploy_code = casper_bytecode + (init_args)
+    deploy_code = casper_bytecode #+ (init_args)
     casper_tx = Transaction(
         nonce,
         GAS_PRICE,
@@ -271,6 +273,10 @@ def casper_chain(
     test_chain.direct_tx(casper_fund_tx)
 
     test_chain.mine(1)
+
+    casper_contract = casper(test_chain, casper_abi, casper_address)
+    casper_contract.init(*casper_args)
+
     return test_chain
 
 
@@ -287,7 +293,7 @@ def deploy_casper_contract(
         base_sender_privkey):
     def deploy_casper_contract(contract_args):
         chain = casper_chain(
-            test_chain, contract_args, casper_code, casper_ct,
+            test_chain, contract_args, casper_code, casper_abi, casper_ct, casper_address,
             dependency_transactions, msg_hasher_address, purity_checker_address,
             base_sender_privkey
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,9 +246,7 @@ def casper_chain(
     # otherwise, vyper compiler cannot properly embed RLP decoder address
     casper_bytecode = compiler.compile(casper_code)
 
-    # init_args = casper_ct.encode_constructor_arguments(casper_args)
-
-    deploy_code = casper_bytecode #+ (init_args)
+    deploy_code = casper_bytecode
     casper_tx = Transaction(
         nonce,
         GAS_PRICE,

--- a/tests/test_chain_initialization.py
+++ b/tests/test_chain_initialization.py
@@ -1,8 +1,4 @@
-import pytest
-
 from ethereum import utils
-from ethereum.tools.tester import TransactionFailed
-from conftest import casper_chain
 
 
 def test_rlp_decoding_is_pure(
@@ -48,44 +44,3 @@ def test_init_first_epoch(casper, new_epoch):
     assert casper.next_validator_index() == 1
     assert casper.current_epoch() == 1
     assert casper.total_slashed(casper.current_epoch()) == 0
-
-
-@pytest.mark.parametrize(
-    'start_epoch',
-    [
-        (0), (1), (4), (10)
-    ]
-)
-def test_start_epoch(test_chain, start_epoch, epoch_length, casper_args, deploy_casper_contract):
-    test_chain.mine(
-        epoch_length * start_epoch - test_chain.head_state.block_number
-    )
-
-    casper = deploy_casper_contract(casper_args)
-    assert casper.START_EPOCH() == start_epoch
-    assert casper.current_epoch() == start_epoch
-
-
-@pytest.mark.parametrize(
-    'epoch_length, success',
-    [
-        (-1, False),
-        (0, False),
-        (10, True),
-        (250, True),
-        (256, False),
-        (500, False),
-    ]
-)
-def test_epoch_length(epoch_length, success, casper_args,
-                      deploy_casper_contract, assert_failed):
-    # Note: cannot use assert_tx_failed because requires casper_chain
-    if not success:
-        assert_failed(
-            lambda: deploy_casper_contract(casper_args),
-            TransactionFailed
-        )
-        return
-
-    casper = deploy_casper_contract(casper_args)
-    assert casper.EPOCH_LENGTH() == epoch_length

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,198 @@
+import pytest
+
+from ethereum.tools.tester import TransactionFailed
+
+
+def test_no_double_init(casper_args,
+                        deploy_casper_contract,
+                        assert_failed):
+    # Note: cannot use assert_tx_failed because requires casper_chain
+    casper = deploy_casper_contract(casper_args, initialize_contract=False)
+
+    casper.init(*casper_args)
+    assert_failed(lambda: casper.init(*casper_args), TransactionFailed)
+
+
+@pytest.mark.parametrize(
+    'start_epoch',
+    [
+        (0), (1), (4), (10)
+    ]
+)
+def test_start_epoch(test_chain, start_epoch, epoch_length, casper_args, deploy_casper_contract):
+    test_chain.mine(
+        epoch_length * start_epoch - test_chain.head_state.block_number
+    )
+
+    casper = deploy_casper_contract(casper_args, initialize_contract=False)
+    casper.init(*casper_args)
+
+    assert casper.START_EPOCH() == start_epoch
+    assert casper.current_epoch() == start_epoch
+
+
+@pytest.mark.parametrize(
+    'epoch_length, success',
+    [
+        (-1, False),
+        (0, False),
+        (10, True),
+        (250, True),
+        (256, False),
+        (500, False),
+    ]
+)
+def test_init_epoch_length(epoch_length, success, casper_args,
+                           deploy_casper_contract, assert_failed):
+    # Note: cannot use assert_tx_failed because requires casper_chain
+    casper = deploy_casper_contract(casper_args, initialize_contract=False)
+
+    if not success:
+        assert_failed(
+            lambda: casper.init(*casper_args),
+            TransactionFailed
+        )
+        return
+
+    casper.init(*casper_args)
+    assert casper.EPOCH_LENGTH() == epoch_length
+
+
+@pytest.mark.parametrize(
+    'withdrawal_delay, success',
+    [
+        (-42, False),
+        (-1, False),
+        (0, True),
+        (1, True),
+        (10, True),
+        (10000, True),
+        (500000000, True),
+    ]
+)
+def test_init_withdrawal_delay(withdrawal_delay, success, casper_args,
+                               deploy_casper_contract, assert_failed):
+    # Note: cannot use assert_tx_failed because requires casper_chain
+    casper = deploy_casper_contract(casper_args, initialize_contract=False)
+
+    if not success:
+        assert_failed(
+            lambda: casper.init(*casper_args),
+            TransactionFailed
+        )
+        return
+
+    casper.init(*casper_args)
+    assert casper.WITHDRAWAL_DELAY() == withdrawal_delay
+
+
+@pytest.mark.parametrize(
+    'dynasty_logout_delay, success',
+    [
+        (-42, False),
+        (-1, False),
+        (0, False),
+        (1, False),
+        (2, True),
+        (3, True),
+        (100, True),
+        (3000000, True),
+    ]
+)
+def test_init_dynasty_logout_delay(dynasty_logout_delay, success, casper_args,
+                                   deploy_casper_contract, assert_failed):
+    # Note: cannot use assert_tx_failed because requires casper_chain
+    casper = deploy_casper_contract(casper_args, initialize_contract=False)
+
+    if not success:
+        assert_failed(
+            lambda: casper.init(*casper_args),
+            TransactionFailed
+        )
+        return
+
+    casper.init(*casper_args)
+    assert casper.DYNASTY_LOGOUT_DELAY() == dynasty_logout_delay
+
+
+@pytest.mark.parametrize(
+    'base_interest_factor, success',
+    [
+        (-10, False),
+        (-0.001, False),
+        (0, True),
+        (7e-3, True),
+        (0.1, True),
+        (1.5, True),
+    ]
+)
+def test_init_base_interest_factor(base_interest_factor, success, casper_args,
+                                   deploy_casper_contract, assert_failed):
+    # Note: cannot use assert_tx_failed because requires casper_chain
+    casper = deploy_casper_contract(casper_args, initialize_contract=False)
+
+    if not success:
+        assert_failed(
+            lambda: casper.init(*casper_args),
+            TransactionFailed
+        )
+        return
+
+    casper.init(*casper_args)
+    assert casper.BASE_INTEREST_FACTOR() == base_interest_factor
+
+
+@pytest.mark.parametrize(
+    'base_penalty_factor, success',
+    [
+        (-10, False),
+        (-0.001, False),
+        (0, True),
+        (7e-3, True),
+        (0.1, True),
+        (1.5, True),
+    ]
+)
+def test_init_base_penalty_factor(base_penalty_factor, success, casper_args,
+                                  deploy_casper_contract, assert_failed):
+    # Note: cannot use assert_tx_failed because requires casper_chain
+    casper = deploy_casper_contract(casper_args, initialize_contract=False)
+
+    if not success:
+        assert_failed(
+            lambda: casper.init(*casper_args),
+            TransactionFailed
+        )
+        return
+
+    casper.init(*casper_args)
+    assert casper.BASE_PENALTY_FACTOR() == base_penalty_factor
+
+
+@pytest.mark.parametrize(
+    'min_deposit_size, success',
+    [
+        (int(-1e10), False),
+        (-1, False),
+        (0, False),
+        (1, True),
+        (42, True),
+        (int(1e4), True),
+        (int(2.5e20), True),
+        (int(5e30), True),
+    ]
+)
+def test_init_min_deposit_size(min_deposit_size, success, casper_args,
+                               deploy_casper_contract, assert_failed):
+    # Note: cannot use assert_tx_failed because requires casper_chain
+    casper = deploy_casper_contract(casper_args, initialize_contract=False)
+
+    if not success:
+        assert_failed(
+            lambda: casper.init(*casper_args),
+            TransactionFailed
+        )
+        return
+
+    casper.init(*casper_args)
+    assert casper.MIN_DEPOSIT_SIZE() == min_deposit_size

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,12 +5,11 @@ from ethereum.tools.tester import TransactionFailed
 
 def test_no_double_init(casper_args,
                         deploy_casper_contract,
-                        assert_failed):
-    # Note: cannot use assert_tx_failed because requires casper_chain
+                        assert_tx_failed):
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
 
     casper.init(*casper_args)
-    assert_failed(lambda: casper.init(*casper_args), TransactionFailed)
+    assert_tx_failed(lambda: casper.init(*casper_args))
 
 
 @pytest.mark.parametrize(
@@ -19,7 +18,8 @@ def test_no_double_init(casper_args,
         (0), (1), (4), (10)
     ]
 )
-def test_start_epoch(test_chain, start_epoch, epoch_length, casper_args, deploy_casper_contract):
+def test_start_epoch(test_chain, start_epoch, epoch_length,
+                     casper_args, deploy_casper_contract):
     test_chain.mine(
         epoch_length * start_epoch - test_chain.head_state.block_number
     )
@@ -43,15 +43,11 @@ def test_start_epoch(test_chain, start_epoch, epoch_length, casper_args, deploy_
     ]
 )
 def test_init_epoch_length(epoch_length, success, casper_args,
-                           deploy_casper_contract, assert_failed):
-    # Note: cannot use assert_tx_failed because requires casper_chain
+                           deploy_casper_contract, assert_tx_failed):
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
 
     if not success:
-        assert_failed(
-            lambda: casper.init(*casper_args),
-            TransactionFailed
-        )
+        assert_tx_failed(lambda: casper.init(*casper_args))
         return
 
     casper.init(*casper_args)
@@ -71,15 +67,11 @@ def test_init_epoch_length(epoch_length, success, casper_args,
     ]
 )
 def test_init_withdrawal_delay(withdrawal_delay, success, casper_args,
-                               deploy_casper_contract, assert_failed):
-    # Note: cannot use assert_tx_failed because requires casper_chain
+                               deploy_casper_contract, assert_tx_failed):
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
 
     if not success:
-        assert_failed(
-            lambda: casper.init(*casper_args),
-            TransactionFailed
-        )
+        assert_tx_failed(lambda: casper.init(*casper_args))
         return
 
     casper.init(*casper_args)
@@ -100,15 +92,11 @@ def test_init_withdrawal_delay(withdrawal_delay, success, casper_args,
     ]
 )
 def test_init_dynasty_logout_delay(dynasty_logout_delay, success, casper_args,
-                                   deploy_casper_contract, assert_failed):
-    # Note: cannot use assert_tx_failed because requires casper_chain
+                                   deploy_casper_contract, assert_tx_failed):
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
 
     if not success:
-        assert_failed(
-            lambda: casper.init(*casper_args),
-            TransactionFailed
-        )
+        assert_tx_failed(lambda: casper.init(*casper_args))
         return
 
     casper.init(*casper_args)
@@ -127,15 +115,11 @@ def test_init_dynasty_logout_delay(dynasty_logout_delay, success, casper_args,
     ]
 )
 def test_init_base_interest_factor(base_interest_factor, success, casper_args,
-                                   deploy_casper_contract, assert_failed):
-    # Note: cannot use assert_tx_failed because requires casper_chain
+                                   deploy_casper_contract, assert_tx_failed):
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
 
     if not success:
-        assert_failed(
-            lambda: casper.init(*casper_args),
-            TransactionFailed
-        )
+        assert_tx_failed(lambda: casper.init(*casper_args))
         return
 
     casper.init(*casper_args)
@@ -154,15 +138,11 @@ def test_init_base_interest_factor(base_interest_factor, success, casper_args,
     ]
 )
 def test_init_base_penalty_factor(base_penalty_factor, success, casper_args,
-                                  deploy_casper_contract, assert_failed):
-    # Note: cannot use assert_tx_failed because requires casper_chain
+                                  deploy_casper_contract, assert_tx_failed):
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
 
     if not success:
-        assert_failed(
-            lambda: casper.init(*casper_args),
-            TransactionFailed
-        )
+        assert_tx_failed(lambda: casper.init(*casper_args))
         return
 
     casper.init(*casper_args)
@@ -183,15 +163,11 @@ def test_init_base_penalty_factor(base_penalty_factor, success, casper_args,
     ]
 )
 def test_init_min_deposit_size(min_deposit_size, success, casper_args,
-                               deploy_casper_contract, assert_failed):
-    # Note: cannot use assert_tx_failed because requires casper_chain
+                               deploy_casper_contract, assert_tx_failed):
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
 
     if not success:
-        assert_failed(
-            lambda: casper.init(*casper_args),
-            TransactionFailed
-        )
+        assert_tx_failed(lambda: casper.init(*casper_args))
         return
 
     casper.init(*casper_args)


### PR DESCRIPTION
Addresses #132 to pave the way for a cleaner deploy of casper in a hard fork.

- remove `__init__`
- add `init`
- add `initialized` flag to prevent double init
- deploy in testing via this `init`
- add explicit testing for all `init` params and tighten up assertions around valid `init` params