### PR TITLE
add `warm_up_period` to `init`

### DIFF
--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -95,6 +95,8 @@ initialized: bool
 
 # Length of an epoch in blocks
 EPOCH_LENGTH: public(int128)
+
+# Length of warm up period in blocks
 WARM_UP_PERIOD: public(int128)
 
 # Withdrawal delay in blocks

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -316,6 +316,8 @@ def get_dirs(path):
     return path, extra_args
 
 
+# Note: If called during "warm_up-period", new_epoch mines all the way through
+# the warm up period until `initialize_epoch` can first be called
 @pytest.fixture
 def new_epoch(casper_chain, casper):
     def new_epoch():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ PURITY_CHECKER_TX_HEX = "0xf90467808506fc23ac00830583c88080b904546104428061000e6
 PURITY_CHECKER_ABI = [{'name': 'check(address)', 'type': 'function', 'constant': True, 'inputs': [{'name': 'addr', 'type': 'address'}], 'outputs': [{'name': 'out', 'type': 'bool'}]}, {'name': 'submit(address)', 'type': 'function', 'constant': False, 'inputs': [{'name': 'addr', 'type': 'address'}], 'outputs': [{'name': 'out', 'type': 'bool'}]}]  # NOQA
 
 EPOCH_LENGTH = 10
+WARM_UP_PERIOD = 0
 DYNASTY_LOGOUT_DELAY = 5
 WITHDRAWAL_DELAY = 5
 BASE_INTEREST_FACTOR = 0.02
@@ -100,6 +101,11 @@ def epoch_length():
 
 
 @pytest.fixture
+def warm_up_period():
+    return WARM_UP_PERIOD
+
+
+@pytest.fixture
 def withdrawal_delay():
     return WITHDRAWAL_DELAY
 
@@ -125,10 +131,11 @@ def min_deposit_size():
 
 
 @pytest.fixture
-def casper_config(epoch_length, withdrawal_delay, dynasty_logout_delay,
+def casper_config(epoch_length, warm_up_period, withdrawal_delay, dynasty_logout_delay,
                   base_interest_factor, base_penalty_factor, min_deposit_size):
     return {
         "epoch_length": epoch_length,  # in blocks
+        "warm_up_period": warm_up_period,  # in blocks
         "withdrawal_delay": withdrawal_delay,  # in epochs
         "dynasty_logout_delay": dynasty_logout_delay,  # in dynasties
         "base_interest_factor": base_interest_factor,
@@ -140,8 +147,8 @@ def casper_config(epoch_length, withdrawal_delay, dynasty_logout_delay,
 @pytest.fixture
 def casper_args(casper_config, msg_hasher_address, purity_checker_address):
     return [
-        casper_config["epoch_length"], casper_config["withdrawal_delay"],
-        casper_config["dynasty_logout_delay"],
+        casper_config["epoch_length"], casper_config["warm_up_period"],
+        casper_config["withdrawal_delay"], casper_config["dynasty_logout_delay"],
         msg_hasher_address, purity_checker_address, casper_config["base_interest_factor"],
         casper_config["base_penalty_factor"], casper_config["min_deposit_size"]
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ PURITY_CHECKER_TX_HEX = "0xf90467808506fc23ac00830583c88080b904546104428061000e6
 PURITY_CHECKER_ABI = [{'name': 'check(address)', 'type': 'function', 'constant': True, 'inputs': [{'name': 'addr', 'type': 'address'}], 'outputs': [{'name': 'out', 'type': 'bool'}]}, {'name': 'submit(address)', 'type': 'function', 'constant': False, 'inputs': [{'name': 'addr', 'type': 'address'}], 'outputs': [{'name': 'out', 'type': 'bool'}]}]  # NOQA
 
 EPOCH_LENGTH = 10
-WARM_UP_PERIOD = 0
+WARM_UP_PERIOD = 20
 DYNASTY_LOGOUT_DELAY = 5
 WITHDRAWAL_DELAY = 5
 BASE_INTEREST_FACTOR = 0.02
@@ -448,11 +448,10 @@ def deposit_validator(casper_chain, casper, validation_addr):
 @pytest.fixture
 def induct_validator(casper_chain, casper, deposit_validator, new_epoch):
     def induct_validator(privkey, value, valcode_type="pure_ecrecover"):
-        if casper.current_epoch() == 0:
-            new_epoch()
         validator_index = deposit_validator(privkey, value, valcode_type)
-        new_epoch()
-        new_epoch()
+        new_epoch()  # justify
+        new_epoch()  # finalize and increment dynasty
+        new_epoch()  # finalize and increment dynasty
         return validator_index
     return induct_validator
 
@@ -466,12 +465,11 @@ def induct_validator(casper_chain, casper, deposit_validator, new_epoch):
 def induct_validators(casper_chain, casper, deposit_validator, new_epoch):
     def induct_validators(privkeys, values):
         start_index = casper.next_validator_index()
-        if casper.current_epoch() == 0:
-            new_epoch()
         for privkey, value in zip(privkeys, values):
             deposit_validator(privkey, value)
-        new_epoch()
-        new_epoch()
+        new_epoch()  # justify
+        new_epoch()  # finalize and increment dynasty
+        new_epoch()  # finalize and increment dynasty
         return list(range(start_index, start_index + len(privkeys)))
     return induct_validators
 

--- a/tests/test_chain_initialization.py
+++ b/tests/test_chain_initialization.py
@@ -34,13 +34,15 @@ def test_msg_hasher_is_pure(
 
 
 # sanity check on casper contract basic functionality
-def test_init_first_epoch(casper, new_epoch):
-    assert casper.current_epoch() == 0
+def test_init_first_epoch(casper_chain, casper, new_epoch, warm_up_period, epoch_length):
+    start_epoch = (casper_chain.head_state.block_number + warm_up_period) // epoch_length
+
+    assert casper.current_epoch() == start_epoch
     assert casper.next_validator_index() == 1
 
     new_epoch()
 
     assert casper.dynasty() == 0
     assert casper.next_validator_index() == 1
-    assert casper.current_epoch() == 1
+    assert casper.current_epoch() == start_epoch + 1
     assert casper.total_slashed(casper.current_epoch()) == 0

--- a/tests/test_deposit.py
+++ b/tests/test_deposit.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ethereum import utils
 
 
@@ -84,3 +86,17 @@ def test_deposit_updates_total_deposits(casper, funded_privkey, deposit_amount,
 
     assert casper.total_curdyn_deposits_in_wei() == deposit_amount
     assert casper.total_prevdyn_deposits_in_wei() == deposit_amount
+
+
+@pytest.mark.parametrize(
+    'warm_up_period',
+    [
+        (10), (25), (100)
+    ]
+)
+def test_deposit_during_warm_up_period(casper, funded_privkey, deposit_amount,
+                                       deposit_validator, warm_up_period):
+    validator_index = deposit_validator(funded_privkey, deposit_amount)
+
+    expected_start_dynasty = casper.dynasty() + 2
+    assert casper.validators__start_dynasty(validator_index) == expected_start_dynasty

--- a/tests/test_fork_choice_helpers.py
+++ b/tests/test_fork_choice_helpers.py
@@ -78,7 +78,7 @@ def test_highest_finalized_epoch_no_validators(casper, new_epoch, min_deposits):
         if min_deposits > 0:
             expected_epoch = -1
         else:
-            if casper.current_epoch() == 0:
+            if casper.current_epoch() == casper.START_EPOCH():
                 expected_epoch = -1
             else:
                 expected_epoch = casper.last_finalized_epoch()
@@ -90,111 +90,112 @@ def test_highest_finalized_epoch_no_validators(casper, new_epoch, min_deposits):
 
 def test_highest_justified_and_epoch(casper, funded_privkey, deposit_amount,
                                      new_epoch, induct_validator, mk_suggested_vote):
+    start_epoch = casper.START_EPOCH()
     validator_index = induct_validator(funded_privkey, deposit_amount)
     higher_deposit = int(deposit_amount * 1.1)
 
     assert casper.total_curdyn_deposits_in_wei() == deposit_amount
-    assert casper.current_epoch() == 3
+    assert casper.current_epoch() == start_epoch + 3  # 3 to induct first dynasty
 
     assert casper.highest_justified_epoch(deposit_amount) == 0
     assert casper.highest_finalized_epoch(deposit_amount) == -1
-    assert casper.highest_justified_epoch(0) == 2
-    assert casper.highest_finalized_epoch(0) == 2
+    assert casper.highest_justified_epoch(0) == start_epoch + 2
+    assert casper.highest_finalized_epoch(0) == start_epoch + 2
     assert casper.highest_justified_epoch(higher_deposit) == 0
     assert casper.highest_finalized_epoch(higher_deposit) == -1
 
     # justify current_epoch in contract
     casper.vote(mk_suggested_vote(validator_index, funded_privkey))
 
-    assert casper.checkpoints__cur_dyn_deposits(3) == 0
-    assert casper.checkpoints__prev_dyn_deposits(3) == 0
-    assert casper.last_justified_epoch() == 3
-    assert casper.last_finalized_epoch() == 2
+    assert casper.checkpoints__cur_dyn_deposits(start_epoch + 3) == 0
+    assert casper.checkpoints__prev_dyn_deposits(start_epoch + 3) == 0
+    assert casper.last_justified_epoch() == start_epoch + 3
+    assert casper.last_finalized_epoch() == start_epoch + 2
 
     assert casper.highest_justified_epoch(deposit_amount) == 0
     assert casper.highest_finalized_epoch(deposit_amount) == -1
-    assert casper.highest_justified_epoch(0) == 3
-    assert casper.highest_finalized_epoch(0) == 2
+    assert casper.highest_justified_epoch(0) == start_epoch + 3
+    assert casper.highest_finalized_epoch(0) == start_epoch + 2
     assert casper.highest_justified_epoch(higher_deposit) == 0
     assert casper.highest_finalized_epoch(higher_deposit) == -1
 
     new_epoch()
     casper.vote(mk_suggested_vote(validator_index, funded_privkey))
 
-    assert casper.checkpoints__cur_dyn_deposits(4) == deposit_amount
-    assert casper.checkpoints__prev_dyn_deposits(4) == 0
-    assert casper.last_justified_epoch() == 4
-    assert casper.last_finalized_epoch() == 3
+    assert casper.checkpoints__cur_dyn_deposits(start_epoch + 4) == deposit_amount
+    assert casper.checkpoints__prev_dyn_deposits(start_epoch + 4) == 0
+    assert casper.last_justified_epoch() == start_epoch + 4
+    assert casper.last_finalized_epoch() == start_epoch + 3
 
     assert casper.highest_justified_epoch(deposit_amount) == 0
     assert casper.highest_finalized_epoch(deposit_amount) == -1
-    assert casper.highest_justified_epoch(0) == 4
-    assert casper.highest_finalized_epoch(0) == 3
+    assert casper.highest_justified_epoch(0) == start_epoch + 4
+    assert casper.highest_finalized_epoch(0) == start_epoch + 3
     assert casper.highest_justified_epoch(higher_deposit) == 0
     assert casper.highest_finalized_epoch(higher_deposit) == -1
 
     new_epoch()
     casper.vote(mk_suggested_vote(validator_index, funded_privkey))
 
-    assert casper.checkpoints__cur_dyn_deposits(5) == deposit_amount
-    assert casper.checkpoints__prev_dyn_deposits(5) == deposit_amount
-    assert casper.last_justified_epoch() == 5
-    assert casper.last_finalized_epoch() == 4
+    assert casper.checkpoints__cur_dyn_deposits(start_epoch + 5) == deposit_amount
+    assert casper.checkpoints__prev_dyn_deposits(start_epoch + 5) == deposit_amount
+    assert casper.last_justified_epoch() == start_epoch + 5
+    assert casper.last_finalized_epoch() == start_epoch + 4
 
     # enough prev and cur deposits in checkpoint 5 for the justified block
-    assert casper.highest_justified_epoch(deposit_amount) == 5
+    assert casper.highest_justified_epoch(deposit_amount) == start_epoch + 5
     # not enough prev and cur deposits in checkpoint 4 for the finalized block
     assert casper.highest_finalized_epoch(deposit_amount) == -1
-    assert casper.highest_justified_epoch(0) == 5
-    assert casper.highest_finalized_epoch(0) == 4
+    assert casper.highest_justified_epoch(0) == start_epoch + 5
+    assert casper.highest_finalized_epoch(0) == start_epoch + 4
     assert casper.highest_justified_epoch(higher_deposit) == 0
     assert casper.highest_finalized_epoch(higher_deposit) == -1
 
     new_epoch()
     casper.vote(mk_suggested_vote(validator_index, funded_privkey))
 
-    assert casper.checkpoints__cur_dyn_deposits(6) > deposit_amount
-    assert casper.checkpoints__prev_dyn_deposits(6) > deposit_amount
-    assert casper.last_justified_epoch() == 6
-    assert casper.last_finalized_epoch() == 5
+    assert casper.checkpoints__cur_dyn_deposits(start_epoch + 6) > deposit_amount
+    assert casper.checkpoints__prev_dyn_deposits(start_epoch + 6) > deposit_amount
+    assert casper.last_justified_epoch() == start_epoch + 6
+    assert casper.last_finalized_epoch() == start_epoch + 5
 
     # enough deposits in checkpoint 6 for justified and checkpoint 5 for finalized!
-    assert casper.highest_justified_epoch(deposit_amount) == 6
-    assert casper.highest_finalized_epoch(deposit_amount) == 5
+    assert casper.highest_justified_epoch(deposit_amount) == start_epoch + 6
+    assert casper.highest_finalized_epoch(deposit_amount) == start_epoch + 5
     assert casper.highest_justified_epoch(higher_deposit) == 0
     assert casper.highest_finalized_epoch(higher_deposit) == -1
-    assert casper.highest_justified_epoch(0) == 6
-    assert casper.highest_finalized_epoch(0) == 5
+    assert casper.highest_justified_epoch(0) == start_epoch + 6
+    assert casper.highest_finalized_epoch(0) == start_epoch + 5
 
     new_epoch()
     # no vote
 
-    assert casper.checkpoints__cur_dyn_deposits(7) > deposit_amount
-    assert casper.checkpoints__prev_dyn_deposits(7) > deposit_amount
-    assert casper.last_justified_epoch() == 6
-    assert casper.last_finalized_epoch() == 5
+    assert casper.checkpoints__cur_dyn_deposits(start_epoch + 7) > deposit_amount
+    assert casper.checkpoints__prev_dyn_deposits(start_epoch + 7) > deposit_amount
+    assert casper.last_justified_epoch() == start_epoch + 6
+    assert casper.last_finalized_epoch() == start_epoch + 5
 
-    assert casper.highest_justified_epoch(deposit_amount) == 6
-    assert casper.highest_finalized_epoch(deposit_amount) == 5
-    assert casper.highest_justified_epoch(0) == 6
-    assert casper.highest_finalized_epoch(0) == 5
+    assert casper.highest_justified_epoch(deposit_amount) == start_epoch + 6
+    assert casper.highest_finalized_epoch(deposit_amount) == start_epoch + 5
+    assert casper.highest_justified_epoch(0) == start_epoch + 6
+    assert casper.highest_finalized_epoch(0) == start_epoch + 5
     assert casper.highest_justified_epoch(higher_deposit) == 0
     assert casper.highest_finalized_epoch(higher_deposit) == -1
 
     new_epoch()
     casper.vote(mk_suggested_vote(validator_index, funded_privkey))
 
-    assert casper.checkpoints__cur_dyn_deposits(8) > deposit_amount
-    assert casper.checkpoints__prev_dyn_deposits(8) > deposit_amount
+    assert casper.checkpoints__cur_dyn_deposits(start_epoch + 8) > deposit_amount
+    assert casper.checkpoints__prev_dyn_deposits(start_epoch + 8) > deposit_amount
     # new justified
-    assert casper.last_justified_epoch() == 8
+    assert casper.last_justified_epoch() == start_epoch + 8
     # no new finalized because not sequential justified blocks
-    assert casper.last_finalized_epoch() == 5
+    assert casper.last_finalized_epoch() == start_epoch + 5
 
-    assert casper.highest_justified_epoch(deposit_amount) == 8
-    assert casper.highest_finalized_epoch(deposit_amount) == 5
-    assert casper.highest_justified_epoch(0) == 8
-    assert casper.highest_finalized_epoch(0) == 5
+    assert casper.highest_justified_epoch(deposit_amount) == start_epoch + 8
+    assert casper.highest_finalized_epoch(deposit_amount) == start_epoch + 5
+    assert casper.highest_justified_epoch(0) == start_epoch + 8
+    assert casper.highest_finalized_epoch(0) == start_epoch + 5
     assert casper.highest_justified_epoch(higher_deposit) == 0
     assert casper.highest_finalized_epoch(higher_deposit) == -1
 
@@ -204,12 +205,12 @@ def test_highest_justified_and_epoch(casper, funded_privkey, deposit_amount,
     assert casper.checkpoints__cur_dyn_deposits(9) > deposit_amount
     assert casper.checkpoints__prev_dyn_deposits(9) > deposit_amount
     # new justified and finalized because sequential justified blocks
-    assert casper.last_justified_epoch() == 9
-    assert casper.last_finalized_epoch() == 8
+    assert casper.last_justified_epoch() == start_epoch + 9
+    assert casper.last_finalized_epoch() == start_epoch + 8
 
-    assert casper.highest_justified_epoch(deposit_amount) == 9
-    assert casper.highest_finalized_epoch(deposit_amount) == 8
-    assert casper.highest_justified_epoch(0) == 9
-    assert casper.highest_finalized_epoch(0) == 8
+    assert casper.highest_justified_epoch(deposit_amount) == start_epoch + 9
+    assert casper.highest_finalized_epoch(deposit_amount) == start_epoch + 8
+    assert casper.highest_justified_epoch(0) == start_epoch + 9
+    assert casper.highest_finalized_epoch(0) == start_epoch + 8
     assert casper.highest_justified_epoch(higher_deposit) == 0
     assert casper.highest_finalized_epoch(higher_deposit) == -1

--- a/tests/test_initialize_epoch.py
+++ b/tests/test_initialize_epoch.py
@@ -2,12 +2,24 @@ import pytest
 
 
 # ensure that our fixture 'new_epoch' functions properly
-def test_new_epoch_fixture(casper_chain, casper, new_epoch):
-    epoch_length = casper.EPOCH_LENGTH()
-    for _ in range(4):
+@pytest.mark.parametrize(
+    'warm_up_period, epoch_length',
+    [
+        (0, 5),
+        (20, 10),
+        (21, 10),
+        (220, 20),
+    ]
+)
+def test_new_epoch_fixture(casper_chain, casper, new_epoch, warm_up_period, epoch_length):
+    for i in range(4):
         prev_epoch = casper.current_epoch()
         prev_block_number = casper_chain.head_state.block_number
-        expected_jump = epoch_length - (prev_block_number % epoch_length)
+        if i == 0:
+            expected_jump = warm_up_period
+            expected_jump += epoch_length - (prev_block_number + warm_up_period) % epoch_length
+        else:
+            expected_jump = epoch_length - (prev_block_number % epoch_length)
 
         new_epoch()
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -3,6 +3,7 @@ from ethereum import utils
 
 
 def test_epoch_insta_finalize_logs(casper, new_epoch, get_logs, casper_chain):
+    start_epoch = casper.START_EPOCH()
     new_epoch()
     new_epoch()
     # Test epoch logs
@@ -12,29 +13,36 @@ def test_epoch_insta_finalize_logs(casper, new_epoch, get_logs, casper_chain):
     log_old = logs[-2]
     log_new = logs[-1]
 
-    assert {'_event_type', '_number', '_checkpoint_hash', '_is_justified', '_is_finalized'} == log_old.keys()
+    log_fields = {
+        '_event_type', '_number', '_checkpoint_hash',
+        '_is_justified', '_is_finalized'
+    }
+    assert log_fields == log_old.keys()
 
     # New epoch log
     assert log_new['_event_type'] == b'Epoch'
-    assert log_new['_number'] == 2
+    assert log_new['_number'] == start_epoch + 2
     last_block_number = casper_chain.block.number
     # block before epoch init == checkpoint hash
-    assert log_new['_checkpoint_hash'] == casper_chain.chain.get_blockhash_by_number(last_block_number - 1)
+    assert log_new['_checkpoint_hash'] == \
+        casper_chain.chain.get_blockhash_by_number(last_block_number - 1)
     assert log_new['_is_justified'] is False
     assert log_new['_is_finalized'] is False
 
     # Insta-finalized previous epoch
     assert log_old['_event_type'] == b'Epoch'
-    assert log_old['_number'] == 1
+    assert log_old['_number'] == start_epoch + 1
     # block before previous epoch init == checkpoint hash
     prev_epoch_block_number = last_block_number - casper.EPOCH_LENGTH() - 1
-    assert log_old['_checkpoint_hash'] == casper_chain.chain.get_blockhash_by_number(prev_epoch_block_number)
+    assert log_old['_checkpoint_hash'] == \
+        casper_chain.chain.get_blockhash_by_number(prev_epoch_block_number)
     assert log_old['_is_justified'] is True
     assert log_old['_is_finalized'] is True
 
 
 def test_epoch_with_validator_logs(casper, new_epoch, get_logs, casper_chain,
-                                   deposit_validator, funded_privkey, deposit_amount, mk_suggested_vote):
+                                   deposit_validator, funded_privkey,
+                                   deposit_amount, mk_suggested_vote):
     validator_index = casper.next_validator_index()
     deposit_validator(funded_privkey, deposit_amount)
     # Validator is registered in Casper
@@ -49,10 +57,12 @@ def test_epoch_with_validator_logs(casper, new_epoch, get_logs, casper_chain,
     casper.vote(mk_suggested_vote(validator_index, funded_privkey))
     receipt = casper_chain.head_state.receipts[-1]
     logs = get_logs(receipt, casper)
-    assert len(logs) == 3 # Vote + Last Epoch + Prev Epoch
+    assert len(logs) == 3  # Vote + Last Epoch + Prev Epoch
     last_epoch_hash = casper_chain.chain.get_blockhash_by_number(last_block_number - 1)
-    last_epoch_log = [log for log in logs
-                      if log['_event_type'] == b'Epoch' and log['_checkpoint_hash'] == last_epoch_hash][0]
+    last_epoch_log = [
+        log for log in logs
+        if log['_event_type'] == b'Epoch' and log['_checkpoint_hash'] == last_epoch_hash
+    ][0]
     assert last_epoch_log['_is_justified'] is True
     assert last_epoch_log['_is_finalized'] is False
 
@@ -62,13 +72,19 @@ def test_epoch_with_validator_logs(casper, new_epoch, get_logs, casper_chain,
 
     receipt = casper_chain.head_state.receipts[-1]
     logs = get_logs(receipt, casper)
-    assert len(logs) == 3 # Vote + Last Epoch + Prev Epoch
+    assert len(logs) == 3  # Vote + Last Epoch + Prev Epoch
     last_epoch_hash = casper_chain.chain.get_blockhash_by_number(last_block_number - 1)
-    last_epoch_log = [log for log in logs
-                      if log['_event_type'] == b'Epoch' and log['_checkpoint_hash'] == last_epoch_hash][0]
-    prev_epoch_hash = casper_chain.chain.get_blockhash_by_number(last_block_number - casper.EPOCH_LENGTH() - 1)
-    prev_epoch_log = [log for log in logs
-                      if log['_event_type'] == b'Epoch' and log['_checkpoint_hash'] == prev_epoch_hash][0]
+    last_epoch_log = [
+        log for log in logs
+        if log['_event_type'] == b'Epoch' and log['_checkpoint_hash'] == last_epoch_hash
+    ][0]
+    prev_epoch_hash = casper_chain.chain.get_blockhash_by_number(
+        last_block_number - casper.EPOCH_LENGTH() - 1
+    )
+    prev_epoch_log = [
+        log for log in logs
+        if log['_event_type'] == b'Epoch' and log['_checkpoint_hash'] == prev_epoch_hash
+    ][0]
 
     assert prev_epoch_log['_is_justified'] is True
     assert prev_epoch_log['_is_finalized'] is True
@@ -78,9 +94,10 @@ def test_epoch_with_validator_logs(casper, new_epoch, get_logs, casper_chain,
 
 
 def test_deposit_log(casper, funded_privkey, new_epoch, deposit_validator,
-              deposit_amount, get_last_log, casper_chain):
+                     deposit_amount, get_last_log, casper_chain):
+    start_epoch = casper.START_EPOCH()
     new_epoch()
-    assert casper.current_epoch() == 1
+    assert casper.current_epoch() == start_epoch + 1
     assert casper.next_validator_index() == 1
 
     validator_index = casper.next_validator_index()
@@ -90,7 +107,11 @@ def test_deposit_log(casper, funded_privkey, new_epoch, deposit_validator,
 
     # Deposit log
     log = get_last_log(casper_chain, casper)
-    assert {'_event_type', '_from', '_validation_address', '_validator_index', '_start_dyn', '_amount'} == log.keys()
+    log_fields = {
+        '_event_type', '_from', '_validation_address',
+        '_validator_index', '_start_dyn', '_amount'
+    }
+    assert log_fields == log.keys()
     assert log['_event_type'] == b'Deposit'
     assert log['_from'] == '0x' + utils.encode_hex(utils.privtoaddr(funded_privkey))
     assert log['_validation_address'] == casper.validators__addr(validator_index)
@@ -100,7 +121,7 @@ def test_deposit_log(casper, funded_privkey, new_epoch, deposit_validator,
 
 
 def test_vote_log(casper, funded_privkey, new_epoch, deposit_validator,
-                     deposit_amount, get_last_log, casper_chain, mk_suggested_vote):
+                  deposit_amount, get_last_log, casper_chain, mk_suggested_vote):
     new_epoch()
     validator_index = casper.next_validator_index()
     deposit_validator(funded_privkey, deposit_amount)
@@ -115,7 +136,11 @@ def test_vote_log(casper, funded_privkey, new_epoch, deposit_validator,
     casper.vote(mk_suggested_vote(validator_index, funded_privkey))
     # Vote log
     log = get_last_log(casper_chain, casper)
-    assert {'_event_type', '_from', '_validator_index', '_target_hash', '_target_epoch', '_source_epoch'} == log.keys()
+    log_fields = {
+        '_event_type', '_from', '_validator_index',
+        '_target_hash', '_target_epoch', '_source_epoch'
+    }
+    assert log_fields == log.keys()
     assert log['_event_type'] == b'Vote'
     assert log['_from'] == '0x' + utils.encode_hex(utils.privtoaddr(funded_privkey))
     assert log['_validator_index'] == validator_index
@@ -200,7 +225,7 @@ def test_withdraw_log(casper, funded_privkey, new_epoch, deposit_validator,
 
 
 def test_slash_log(casper, funded_privkey, deposit_amount, get_last_log, base_sender_privkey,
-                              induct_validator, mk_vote, fake_hash, casper_chain):
+                   induct_validator, mk_vote, fake_hash, casper_chain):
     validator_index = induct_validator(funded_privkey, deposit_amount)
     assert casper.total_curdyn_deposits_in_wei() == deposit_amount
 
@@ -229,7 +254,8 @@ def test_slash_log(casper, funded_privkey, deposit_amount, get_last_log, base_se
 
     # Slash log
     log = get_last_log(casper_chain, casper)
-    assert {'_event_type', '_from', '_offender', '_offender_index', '_bounty', '_destroyed'} == log.keys()
+    log_fields = {'_event_type', '_from', '_offender', '_offender_index', '_bounty', '_destroyed'}
+    assert log_fields == log.keys()
     assert log['_event_type'] == b'Slash'
     assert log['_from'] == '0x' + utils.encode_hex(utils.privtoaddr(base_sender_privkey))
     assert log['_offender'] == '0x' + utils.encode_hex(utils.privtoaddr(funded_privkey))

--- a/tests/test_slashing.py
+++ b/tests/test_slashing.py
@@ -122,7 +122,7 @@ def test_slash_no_dbl_prepare(casper, funded_privkey, deposit_amount,
 
     assert casper.total_slashed(casper.current_epoch()) == deposit_amount
     assert casper.dynasty_wei_delta(next_dynasty) == \
-        (-deposit_amount / casper.deposit_scale_factor())
+        (-deposit_amount / casper.deposit_scale_factor(casper.current_epoch()))
     assert casper.validators__is_slashed(validator_index)
     assert casper.validators__end_dynasty(validator_index) == next_dynasty
     assert casper.validators__total_deposits_at_logout(validator_index) == deposit_amount
@@ -130,6 +130,7 @@ def test_slash_no_dbl_prepare(casper, funded_privkey, deposit_amount,
 
 def test_slash_no_surround(casper, funded_privkey, deposit_amount, new_epoch,
                            induct_validator, mk_vote, fake_hash, assert_tx_failed):
+    new_epoch()
     validator_index = induct_validator(funded_privkey, deposit_amount)
     assert casper.total_curdyn_deposits_in_wei() == deposit_amount
 
@@ -159,7 +160,7 @@ def test_slash_no_surround(casper, funded_privkey, deposit_amount, new_epoch,
 
     assert casper.total_slashed(casper.current_epoch()) == deposit_amount
     assert casper.dynasty_wei_delta(next_dynasty) == \
-        (-deposit_amount / casper.deposit_scale_factor())
+        (-deposit_amount / casper.deposit_scale_factor(casper.current_epoch()))
     assert casper.validators__is_slashed(validator_index)
     assert casper.validators__end_dynasty(validator_index) == next_dynasty
     assert casper.validators__total_deposits_at_logout(validator_index) == deposit_amount

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -18,8 +18,9 @@ from ethereum.tools import tester
 )
 def test_deposit(casper_chain, casper, privkey, amount,
                  success, deposit_validator, new_epoch, assert_tx_failed):
+    start_epoch = casper.START_EPOCH()
     new_epoch()
-    assert casper.current_epoch() == 1
+    assert casper.current_epoch() == start_epoch + 1
     assert casper.next_validator_index() == 1
 
     if not success:


### PR DESCRIPTION
addresses #140 

- add `warm_up_period` param to `init`. Sets `START_EPOCH` and initial `current_epoch` to an epoch in the future and thus stops calls to `initialize_epoch` until then.
- add `WARM_UP_PERIOD` constant on the contract. I dont think we actually need this. Might want a method for validators to know if we are still in the warm up period. Will think about it in the morning.
- add explicit tests for `warm_up_period` functionality
- make all tests have a warm_up_period as default because that is how we expect to deploy. A lot of tests assumed we started at `epoch == 0` so I had to fix them to assume we start at `START_EPOCH`