### PR TITLE
Port to eth-tester/web3.py

### DIFF
--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -123,11 +123,17 @@ SLASH_FRACTION_MULTIPLIER: int128
 
 
 @public
-def init(epoch_length: int128, warm_up_period: int128,
-         withdrawal_delay: int128, dynasty_logout_delay: int128,
-         msg_hasher: address, purity_checker: address,
-         base_interest_factor: decimal, base_penalty_factor: decimal,
-         min_deposit_size: wei_value):
+def init(
+        epoch_length: int128,
+        warm_up_period: int128,
+        withdrawal_delay: int128,
+        dynasty_logout_delay: int128,
+        msg_hasher: address,
+        purity_checker: address,
+        base_interest_factor: decimal,
+        base_penalty_factor: decimal,
+        min_deposit_size: wei_value
+        ):
 
     assert not self.initialized
     assert epoch_length > 0 and epoch_length < 256
@@ -194,7 +200,7 @@ def sqrt_of_total_deposits() -> decimal:
 @private
 @constant
 def deposit_exists() -> bool:
-    return self.total_curdyn_deposits > 0 and self.total_prevdyn_deposits > 0
+    return self.total_curdyn_deposits > 0.0 and self.total_prevdyn_deposits > 0.0
 
 
 # ***** Private *****
@@ -279,7 +285,7 @@ def delete_validator(validator_index: int128):
 # cannot be labeled @constant because of external call
 # even though the call is to a pure contract call
 @private
-def validate_signature(msg_hash: bytes32, sig: bytes <= 1024, validator_index: int128) -> bool:
+def validate_signature(msg_hash: bytes32, sig: bytes[1024], validator_index: int128) -> bool:
     return extract32(raw_call(self.validators[validator_index].addr, concat(msg_hash, sig), gas=self.VALIDATION_GAS_LIMIT, outsize=32), 0) == convert(1, 'bytes32')
 
 
@@ -313,7 +319,7 @@ def total_prevdyn_deposits_in_wei() -> wei_value:
 @public
 # cannot be labeled @constant because of external call
 # even though the call is to a pure contract call
-def slashable(vote_msg_1: bytes <= 1024, vote_msg_2: bytes <= 1024) -> bool:
+def slashable(vote_msg_1: bytes[1024], vote_msg_2: bytes[1024]) -> bool:
     # Message 1: Extract parameters
     msg_hash_1: bytes32 = extract32(
         raw_call(self.MSG_HASHER, vote_msg_1, gas=self.MSG_HASHER_GAS_LIMIT, outsize=32),
@@ -323,7 +329,7 @@ def slashable(vote_msg_1: bytes <= 1024, vote_msg_2: bytes <= 1024) -> bool:
     validator_index_1: int128 = values_1[0]
     target_epoch_1: int128 = values_1[2]
     source_epoch_1: int128 = values_1[3]
-    sig_1: bytes <= 1024 = values_1[4]
+    sig_1: bytes[1024] = values_1[4]
 
     # Message 2: Extract parameters
     msg_hash_2: bytes32 = extract32(
@@ -334,7 +340,7 @@ def slashable(vote_msg_1: bytes <= 1024, vote_msg_2: bytes <= 1024) -> bool:
     validator_index_2: int128 = values_2[0]
     target_epoch_2: int128 = values_2[2]
     source_epoch_2: int128 = values_2[3]
-    sig_2: bytes <= 1024 = values_2[4]
+    sig_2: bytes[1024] = values_2[4]
 
     if not self.validate_signature(msg_hash_1, sig_1, validator_index_1):
         return False
@@ -447,7 +453,7 @@ def initialize_epoch(epoch: int128):
         adj_interest_base: decimal = self.BASE_INTEREST_FACTOR / self.sqrt_of_total_deposits()
         self.reward_factor = adj_interest_base + self.BASE_PENALTY_FACTOR * (self.esf() - 2)
         # ESF is only thing that is changing and reward_factor is being used above.
-        assert self.reward_factor > 0
+        assert self.reward_factor > 0.0
     else:
         # Before the first validator deposits, new epochs are finalized instantly.
         self.insta_finalize()
@@ -488,7 +494,7 @@ def deposit(validation_addr: address, withdrawal_addr: address):
 
 
 @public
-def logout(logout_msg: bytes <= 1024):
+def logout(logout_msg: bytes[1024]):
     assert self.current_epoch == floor(block.number / self.EPOCH_LENGTH)
 
     # Get hash for signature, and implicitly assert that it is an RLP list
@@ -500,7 +506,7 @@ def logout(logout_msg: bytes <= 1024):
     values = RLPList(logout_msg, [int128, int128, bytes])
     validator_index: int128 = values[0]
     epoch: int128 = values[1]
-    sig: bytes <= 1024 = values[2]
+    sig: bytes[1024] = values[2]
 
     assert self.current_epoch >= epoch
     from_withdrawal: bool = msg.sender == self.validators[validator_index].withdrawal_addr
@@ -547,7 +553,7 @@ def withdraw(validator_index: int128):
 
 # Process a vote message
 @public
-def vote(vote_msg: bytes <= 1024):
+def vote(vote_msg: bytes[1024]):
     # Get hash for signature, and implicitly assert that it is an RLP list
     # consisting solely of RLP elements
     msg_hash: bytes32 = extract32(
@@ -560,7 +566,7 @@ def vote(vote_msg: bytes <= 1024):
     target_hash: bytes32 = values[1]
     target_epoch: int128 = values[2]
     source_epoch: int128 = values[3]
-    sig: bytes <= 1024 = values[4]
+    sig: bytes[1024] = values[4]
 
     assert self.validate_signature(msg_hash, sig, validator_index)
     # Check that this vote has not yet been made
@@ -628,7 +634,7 @@ def vote(vote_msg: bytes <= 1024):
 
 # Cannot sign two votes for same target_epoch; no surround vote.
 @public
-def slash(vote_msg_1: bytes <= 1024, vote_msg_2: bytes <= 1024):
+def slash(vote_msg_1: bytes[1024], vote_msg_2: bytes[1024]):
     assert self.slashable(vote_msg_1, vote_msg_2)
 
     # Extract validator_index

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-rlp==0.6.0
-git+https://github.com/ethereum/pyethereum.git@cba5954a43a2db4df7504d9ced70c63530247e77
+rlp==1.0.1
+eth-tester[py-evm]==0.1.0b24
 pytest==3.4.0
-git+https://github.com/ethereum/vyper.git@v0.0.4
+git+https://github.com/ethereum/vyper.git@248c723288e84899908048efff4c3e0b12f0b3dc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 rlp==1.0.1
 eth-tester[py-evm]==0.1.0b24
+web3>=4.2.1
 pytest==3.4.0
 git+https://github.com/ethereum/vyper.git@248c723288e84899908048efff4c3e0b12f0b3dc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@ import pytest
 import os
 import rlp
 
-from decimal import Decimal
+from decimal import (
+    Decimal,
+)
 
 import eth_tester
 from eth_tester import (
@@ -11,9 +13,6 @@ from eth_tester import (
 )
 from web3.providers.eth_tester import (
     EthereumTesterProvider,
-)
-from eth_tester.exceptions import (
-    TransactionFailed,
 )
 from web3 import (
     Web3,
@@ -371,14 +370,17 @@ def concise_casper(casper):
 @pytest.fixture
 def deploy_casper_contract(
         w3,
-        blank_tester,
+        base_tester,
         casper_code,
         casper_abi,
         casper_address,
+        deploy_rlp_decoder,
+        deploy_msg_hasher,
+        deploy_purity_checker,
         base_sender):
     def deploy_casper_contract(contract_args, initialize_contract=True):
         t = tester(
-            w3, blank_tester, contract_args, casper_code, casper_abi, casper_address,
+            w3, base_tester, contract_args, casper_code, casper_abi, casper_address,
             deploy_rlp_decoder, deploy_msg_hasher, deploy_purity_checker,
             base_sender, initialize_contract
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,6 @@ BASE_INTEREST_FACTOR = Decimal('0.02')
 BASE_PENALTY_FACTOR = Decimal('0.002')
 MIN_DEPOSIT_SIZE = 1000 * 10**18  # 1000 ether
 
-# FUNDED_PRIVKEYS = [ethereum_tester.k1, ethereum_tester.k2, ethereum_tester.k3, ethereum_tester.k4, ethereum_tester.k5]
 DEPOSIT_AMOUNTS = [
     2000 * 10**18,
     # 1000 * 10**18,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,27 @@ import pytest
 import os
 import rlp
 
+import eth_tester
+from eth_tester import (
+    EthereumTester,
+    PyEVMBackend
+)
+from web3.providers.eth_tester import (
+    EthereumTesterProvider,
+)
+from web3 import (
+    Web3
+)
+from vyper import (
+    compiler,
+    utils as vyper_utils,
+)
+
 from ethereum.abi import ContractTranslator
 from ethereum.genesis_helpers import mk_basic_state
 from ethereum.transactions import Transaction
-from ethereum.tools import tester
+from ethereum.tools import ethereum_tester
 from ethereum import utils
-from vyper import compiler
 
 from utils.valcodes import compile_valcode_to_evm_bytecode
 
@@ -16,8 +31,11 @@ OWN_DIR = os.path.dirname(os.path.realpath(__file__))
 GAS_PRICE = 25 * 10**9
 
 VYPER_RLP_DECODER_TX_HEX = "0xf9035b808506fc23ac0083045f788080b903486103305660006109ac5260006109cc527f0100000000000000000000000000000000000000000000000000000000000000600035046109ec526000610a0c5260006109005260c06109ec51101515585760f86109ec51101561006e5760bf6109ec510336141558576001610a0c52610098565b60013560f76109ec51036020035260005160f66109ec510301361415585760f66109ec5103610a0c525b61022060016064818352015b36610a0c511015156100b557610291565b7f0100000000000000000000000000000000000000000000000000000000000000610a0c5135046109ec526109cc5160206109ac51026040015260016109ac51016109ac5260806109ec51101561013b5760016109cc5161044001526001610a0c516109cc5161046001376001610a0c5101610a0c5260216109cc51016109cc52610281565b60b86109ec5110156101d15760806109ec51036109cc51610440015260806109ec51036001610a0c51016109cc51610460013760816109ec5114156101ac5760807f01000000000000000000000000000000000000000000000000000000000000006001610a0c5101350410151558575b607f6109ec5103610a0c5101610a0c5260606109ec51036109cc51016109cc52610280565b60c06109ec51101561027d576001610a0c51013560b76109ec510360200352600051610a2c526038610a2c5110157f01000000000000000000000000000000000000000000000000000000000000006001610a0c5101350402155857610a2c516109cc516104400152610a2c5160b66109ec5103610a0c51016109cc516104600137610a2c5160b66109ec5103610a0c510101610a0c526020610a2c51016109cc51016109cc5261027f565bfe5b5b5b81516001018083528114156100a4575b5050601f6109ac511115155857602060206109ac5102016109005260206109005103610a0c5261022060016064818352015b6000610a0c5112156102d45761030a565b61090051610a0c516040015101610a0c51610900516104400301526020610a0c5103610a0c5281516001018083528114156102c3575b50506109cc516109005101610420526109cc5161090051016109005161044003f35b61000461033003610004600039610004610330036000f31b2d4f"  # NOQA
+VYPER_RLP_DECODER_TX_SENDER = "0x39ba083c30fCe59883775Fc729bBE1f9dE4DEe11"
 MSG_HASHER_TX_HEX = "0xf9016d808506fc23ac0083026a508080b9015a6101488061000e6000396101565660007f01000000000000000000000000000000000000000000000000000000000000006000350460f8811215610038576001915061003f565b60f6810391505b508060005b368312156100c8577f01000000000000000000000000000000000000000000000000000000000000008335048391506080811215610087576001840193506100c2565b60b881121561009d57607f8103840193506100c1565b60c08112156100c05760b68103600185013560b783036020035260005101840193505b5b5b50610044565b81810360388112156100f4578060c00160005380836001378060010160002060e052602060e0f3610143565b61010081121561010557600161011b565b6201000081121561011757600261011a565b60035b5b8160005280601f038160f701815382856020378282600101018120610140526020610140f350505b505050505b6000f31b2d4f"  # NOQA
+MSG_HASHER_TX_SENDER = "0xd7a3bd6c9ea32eff147d067f907ae6b22d436f91"
 PURITY_CHECKER_TX_HEX = "0xf90467808506fc23ac00830583c88080b904546104428061000e60003961045056600061033f537c0100000000000000000000000000000000000000000000000000000000600035047f80010000000000000000000000000000000000000030ffff1c0e00000000000060205263a1903eab8114156103f7573659905901600090523660048237600435608052506080513b806020015990590160009052818152602081019050905060a0526080513b600060a0516080513c6080513b8060200260200159905901600090528181526020810190509050610100526080513b806020026020015990590160009052818152602081019050905061016052600060005b602060a05103518212156103c957610100601f8360a051010351066020518160020a161561010a57fe5b80606013151561011e57607f811315610121565b60005b1561014f5780607f036101000a60018460a0510101510482602002610160510152605e8103830192506103b2565b60f18114801561015f5780610164565b60f282145b905080156101725780610177565b60f482145b9050156103aa5760028212151561019e5760606001830360200261010051015112156101a1565b60005b156101bc57607f6001830360200261010051015113156101bf565b60005b156101d157600282036102605261031e565b6004821215156101f057600360018303602002610100510151146101f3565b60005b1561020d57605a6002830360200261010051015114610210565b60005b1561022b57606060038303602002610100510151121561022e565b60005b1561024957607f60038303602002610100510151131561024c565b60005b1561025e57600482036102605261031d565b60028212151561027d57605a6001830360200261010051015114610280565b60005b1561029257600282036102605261031c565b6002821215156102b157609060018303602002610100510151146102b4565b60005b156102c657600282036102605261031b565b6002821215156102e65760806001830360200261010051015112156102e9565b60005b156103035760906001830360200261010051015112610306565b60005b1561031857600282036102605261031a565bfe5b5b5b5b5b604060405990590160009052600081526102605160200261016051015181602001528090502054156103555760016102a052610393565b60306102605160200261010051015114156103755760016102a052610392565b60606102605160200261010051015114156103915760016102a0525b5b5b6102a051151561039f57fe5b6001830192506103b1565b6001830192505b5b8082602002610100510152600182019150506100e0565b50506001604060405990590160009052600081526080518160200152809050205560016102e05260206102e0f35b63c23697a8811415610440573659905901600090523660048237600435608052506040604059905901600090526000815260805181602001528090502054610300526020610300f35b505b6000f31b2d4f"  # NOQA
+PURITY_CHECKER_TX_SENDER = "0xea0f0d55ee82edf248ed648a9a8d213fba8b5081"
 PURITY_CHECKER_ABI = [{'name': 'check(address)', 'type': 'function', 'constant': True, 'inputs': [{'name': 'addr', 'type': 'address'}], 'outputs': [{'name': 'out', 'type': 'bool'}]}, {'name': 'submit(address)', 'type': 'function', 'constant': False, 'inputs': [{'name': 'addr', 'type': 'address'}], 'outputs': [{'name': 'out', 'type': 'bool'}]}]  # NOQA
 
 EPOCH_LENGTH = 10
@@ -28,16 +46,47 @@ BASE_INTEREST_FACTOR = 0.02
 BASE_PENALTY_FACTOR = 0.002
 MIN_DEPOSIT_SIZE = 1000 * 10**18  # 1000 ether
 
-FUNDED_PRIVKEYS = [tester.k1, tester.k2, tester.k3, tester.k4, tester.k5]
+FUNDED_PRIVKEYS = [ethereum_tester.k1, ethereum_tester.k2, ethereum_tester.k3, ethereum_tester.k4, ethereum_tester.k5]
 DEPOSIT_AMOUNTS = [
     2000 * 10**18,
     # 1000 * 10**18,
 ]
 
 
+def next_contract_address(base_tester, fake_contract_code):
+    def next_contract_address(sender):
+        snapshot_id = base_tester.take_snapshot()
+        bytecode = compiler.compile(fake_contract_code)
+        tx_hash = w3.eth.sendTransaction({
+            'from': sender,
+            'to': '',
+            'gas': 7000000,
+            'data': bytecode
+        })
+        contract_address = w3.eth.getTransactionReceipt(tx_hash).contractAddress
+
+        base_tester.revert_to_snapshot(snapshot_id)
+        return contract_address
+    return next_contract_address
+
+
 @pytest.fixture
 def fake_hash():
     return b'\xbc' * 32
+
+
+@pytest.fixture
+def fake_contract_code():
+    return '''
+@public
+def five() -> uint256
+     return 5
+'''
+
+
+@pytest.fixture
+def base_sender(base_tester):
+    return base_tester.get_accounts()[-1]
 
 
 @pytest.fixture
@@ -66,8 +115,8 @@ def vyper_rlp_decoder_tx():
 
 
 @pytest.fixture
-def vyper_rlp_decoder_address(vyper_rlp_decoder_tx):
-    return vyper_rlp_decoder_tx.creates
+def vyper_rlp_decoder_address(next_contract_address):
+    return next_contract_address(VYPER_RLP_DECODER_TX_SENDER)
 
 
 @pytest.fixture
@@ -76,7 +125,22 @@ def msg_hasher_tx():
 
 
 @pytest.fixture
-def msg_hasher_address(msg_hasher_tx):
+def msg_hasher_address(base_tester, fake_code):
+    snapshot_id = base_tester.take_snapshot()
+    bytecode = compiler.compile(fake_code)
+    tx_hash = w3.eth.sendTransaction({
+        'from': base_sender,
+        'to': '',
+        'gas': 7000000,
+        'data': bytecode
+    })
+    contract_address = w3.eth.getTransactionReceipt(tx_hash).contractAddress
+
+    base_tester.revert_to_snapshot(snapshot_id)
+    return contract_address
+
+
+
     return msg_hasher_tx.creates
 
 
@@ -86,8 +150,8 @@ def purity_checker_tx():
 
 
 @pytest.fixture
-def purity_checker_address(purity_checker_tx):
-    return purity_checker_tx.creates
+def purity_checker_address(next_contract_address):
+    return next_contract_address(PURITY_CHECKER_TX_SENDER)
 
 
 @pytest.fixture
@@ -154,6 +218,121 @@ def casper_args(casper_config, msg_hasher_address, purity_checker_address):
     ]
 
 
+setattr(eth_tester.backends.pyevm.main, 'GENESIS_GAS_LIMIT', 10**9)
+setattr(eth_tester.backends.pyevm.main, 'GENESIS_DIFFICULTY', 1)
+
+
+@pytest.fixture
+def base_tester():
+    return EthereumTester(PyEVMBackend())
+
+
+def zero_gas_price_strategy(web3, transaction_params=None):
+    return 0  # zero gas price makes testing simpler.
+
+
+@pytest.fixture(scope="module")
+def w3(base_tester):
+    w3 = Web3(EthereumTesterProvider(tester))
+    w3.eth.setGasPriceStrategy(zero_gas_price_strategy)
+    return w3
+
+
+@pytest.fixture
+def deploy_rlp_decoder(tester, w3):
+    def deploy_rlp_decoder():
+        w3.eth.sendTransaction({
+            'to': VYPER_RLP_DECODER_TX_SENDER,
+            'value': 10**17
+        })
+        tx_hash = w3.eth.sendRawTransaction(VYPER_RLP_DECODER_TX_HEX)
+
+        receipt = w3.eth.getTransactionReceipt(tx_hash)
+        contract_address = receipt.contractAddress
+        assert vyper_utils.RLP_DECODER_ADDRESS == w3.toInt(hexstr=contract_address)
+        return contract_address
+
+
+@pytest.fixture
+def deploy_msg_hasher(tester, w3):
+    def deploy_msg_hasher():
+        w3.eth.sendTransaction({
+            'to': MSG_HASHER_TX_SENDER,
+            'value': 10**17
+        })
+        tx_hash = w3.eth.sendRawTransaction(MSG_HASHER_TX_HEX)
+
+        receipt = w3.eth.getTransactionReceipt(tx_hash)
+        return receipt.contractAddress
+
+
+@pytest.fixture
+def deploy_purity_checker(tester, w3):
+    def deploy_purity_checker():
+        w3.eth.sendTransaction({
+            'to': PURITY_CHECKER_TX_SENDER,
+            'value': 10**17
+        })
+        tx_hash = w3.eth.sendRawTransaction(PURITY_CHECKER_TX_SENDER)
+
+        receipt = w3.eth.getTransactionReceipt(tx_hash)
+        return receipt.contractAddress
+
+
+@pytest.fixture
+def tester(
+        w3,
+        base_tester,
+        casper_args,
+        casper_code,
+        casper_abi,
+        casper_ct,
+        casper_address,
+        deploy_rlp_decoder,
+        deploy_msg_hasher,
+        deploy_purity_checker,
+        dependency_transactions,
+        msg_hasher_address,
+        purity_checker_address,
+        base_sender,
+        initialize_contract=True):
+    deploy_rlp_decoder()
+    msg_hasher_address = deploy_msg_hasher()
+    purity_checker_address = deploy_purity_checker()
+
+    # NOTE: bytecode cannot be compiled before RLP Decoder is deployed to chain
+    # otherwise, vyper compiler cannot properly embed RLP decoder address
+    casper_bytecode = compiler.compile(casper_code)
+
+    deploy_code = casper_bytecode
+    tx_hash = w3.eth.sendTransaction({
+        'from': base_sender,
+        'to': '',
+        'gas': 7000000,
+        'data': deploy_code
+    })
+    casper_address = w3.eth.getTransactionReceipt(tx_hash).contractAddress
+
+    # Casper contract needs money for its activity
+    w3.eth.sendTransaction({
+        'to': casper_address,
+        'value': 10**21
+    })
+
+    Casper = w3.eth.contract(abi=casper_abi, bytecode=casper_bytecode)
+    tx_hash = Casper.constructor().transact()
+    tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+
+    assert tx_receipt.contractAddress == casper_address
+
+    if initialize_contract:
+        casper_contract = casper(w3, base_tester, casper_abi, casper_address)
+        casper_contract.functions.init(*casper_args).transact()
+
+    return tester
+
+
+'''
 @pytest.fixture
 def test_chain(alloc=tester.base_alloc, genesis_gas_limit=9999999,
                min_gas_limit=5000, startgas=3141592):
@@ -171,6 +350,7 @@ def test_chain(alloc=tester.base_alloc, genesis_gas_limit=9999999,
     chain.chain.env.config['MIN_GAS_LIMIT'] = min_gas_limit
     chain.mine(1)
     return chain
+'''
 
 
 @pytest.fixture
@@ -195,96 +375,17 @@ def dependency_transactions(vyper_rlp_decoder_tx, msg_hasher_tx, purity_checker_
 
 
 @pytest.fixture
-def casper_address(dependency_transactions, base_sender_privkey):
-    mock_tx = Transaction(
-        len(dependency_transactions),
-        GAS_PRICE,
-        500000,
-        b'',
-        0,
-        "0x0"
-    ).sign(base_sender_privkey)
-    return mock_tx.creates
+def casper_address(next_contract_address, base_sender):
+    return next_contract_address(base_sender)
 
 
 @pytest.fixture
-def casper(casper_chain, casper_abi, casper_address):
-    return tester.ABIContract(casper_chain, casper_abi, casper_address)
-
-
-@pytest.fixture
-def casper_chain(
-        test_chain,
-        casper_args,
-        casper_code,
-        casper_abi,
-        casper_ct,
-        casper_address,
-        dependency_transactions,
-        msg_hasher_address,
-        purity_checker_address,
-        base_sender_privkey,
-        initialize_contract=True):
-    init_transactions = []
-    nonce = 0
-    # Create transactions for instantiating RLP decoder, msg hasher and purity checker,
-    # plus transactions for feeding the one-time accounts that generate those transactions
-    for tx in dependency_transactions:
-        fund_gas_tx = Transaction(
-            nonce,
-            GAS_PRICE,
-            500000,
-            tx.sender,
-            tx.startgas * tx.gasprice + tx.value,
-            ''
-        ).sign(base_sender_privkey)
-        init_transactions.append(fund_gas_tx)
-        init_transactions.append(tx)
-        nonce += 1
-
-    for tx in init_transactions:
-        if test_chain.head_state.gas_used + tx.startgas > test_chain.head_state.gas_limit:
-            test_chain.mine(1)
-        test_chain.direct_tx(tx)
-
-    test_chain.mine(1)
-
-    # NOTE: bytecode cannot be compiled before RLP Decoder is deployed to chain
-    # otherwise, vyper compiler cannot properly embed RLP decoder address
-    casper_bytecode = compiler.compile(casper_code)
-
-    deploy_code = casper_bytecode
-    casper_tx = Transaction(
-        nonce,
-        GAS_PRICE,
-        7000000,
-        b'',
-        0,
-        deploy_code
-    ).sign(base_sender_privkey)
-    test_chain.direct_tx(casper_tx)
-    nonce += 1
-
-    test_chain.mine(1)
-
-    # Casper contract needs money for its activity
-    casper_fund_tx = Transaction(
-        nonce,
-        GAS_PRICE,
-        5000000,
-        casper_tx.creates,
-        10**21,
-        b''
-    ).sign(base_sender_privkey)
-    test_chain.direct_tx(casper_fund_tx)
-
-    test_chain.mine(1)
-
-    if initialize_contract:
-        casper_contract = casper(test_chain, casper_abi, casper_address)
-        casper_contract.init(*casper_args)
-
-    return test_chain
+def casper(w3, tester, casper_abi, casper_address):
+    casper = w3.eth.contract(
+        address=casper_address,
+        abi=casper_abi
+    )
+    return casper
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,10 +112,20 @@ def funded_accounts(base_tester):
 
 
 @pytest.fixture
+def funded_account(funded_accounts):
+    return funded_accounts[0]
+
+
+@pytest.fixture
 def validation_keys(w3, funded_accounts):
     # use address as the keymash to gen new private keys
     # insecure but fine for our purposes
     return [w3.eth.account.create(str(address)).privateKey for address in funded_accounts]
+
+
+@pytest.fixture
+def validation_key(validation_keys):
+    return validation_keys[0]
 
 
 @pytest.fixture
@@ -542,9 +552,19 @@ def deposit_validator(w3, tester, casper, deploy_validation_contract):
 #       If inducting a validator when desposits exists, use `deposit_validator` and
 #       manually finalize
 @pytest.fixture
-def induct_validator(casper_chain, casper, deposit_validator, new_epoch):
-    def induct_validator(privkey, value, valcode_type="pure_ecrecover"):
-        validator_index = deposit_validator(privkey, value, valcode_type)
+def induct_validator(w3, tester, casper, deposit_validator, new_epoch):
+    def induct_validator(
+            withdrawal_addr,
+            validation_key,
+            value,
+            valcode_type="pure_ecrecover"):
+
+        validator_index = deposit_validator(
+            withdrawal_addr,
+            validation_key,
+            value,
+            valcode_type
+        )
         new_epoch()  # justify
         new_epoch()  # finalize and increment dynasty
         new_epoch()  # finalize and increment dynasty

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -482,7 +482,7 @@ def mk_logout_msg_signed(w3):
 def mk_logout_msg_unsigned():
     def mk_logout_msg_unsigned(validator_index, epoch):
         v, r, s = (0, 0, 0)
-        sig = utils.encode_int32(v) + utils.encode_int32(r) + utils.encode_int32(s)
+        sig = encode_int32(v) + encode_int32(r) + encode_int32(s)
         return rlp.encode([validator_index, epoch, sig])
     return mk_logout_msg_unsigned
 
@@ -491,21 +491,21 @@ def mk_logout_msg_unsigned():
 def logout_validator_via_signed_msg(casper, concise_casper, mk_logout_msg_signed, base_sender):
     def logout_validator_via_signed_msg(validator_index,
                                         msg_signing_key,
-                                        tx_sender_address=base_sender):
+                                        tx_sender_addr=base_sender):
         logout_msg = mk_logout_msg_signed(
             validator_index,
             concise_casper.current_epoch(),
             msg_signing_key
         )
-        casper.functions.logout(logout_msg).transact({'from': tx_sender_address})
+        casper.functions.logout(logout_msg).transact({'from': tx_sender_addr})
     return logout_validator_via_signed_msg
 
 
 @pytest.fixture
-def logout_validator_via_unsigned_msg(casper, mk_logout_msg_unsigned):
-    def logout_validator_via_unsigned_msg(validator_index, tx_sender_key):
-        logout_tx = mk_logout_msg_unsigned(validator_index, casper.current_epoch())
-        casper.logout(logout_tx, sender=tx_sender_key)
+def logout_validator_via_unsigned_msg(casper, concise_casper, mk_logout_msg_unsigned):
+    def logout_validator_via_unsigned_msg(validator_index, tx_sender_addr):
+        logout_tx = mk_logout_msg_unsigned(validator_index, concise_casper.current_epoch())
+        casper.functions.logout(logout_tx).transact({'from': tx_sender_addr})
     return logout_validator_via_unsigned_msg
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,6 +360,36 @@ def casper_address(next_contract_address, base_sender):
 
 
 @pytest.fixture
+def casper_deposit_filter(casper):
+    return casper.events.Deposit.createFilter(fromBlock='latest')
+
+
+@pytest.fixture
+def casper_vote_filter(casper):
+    return casper.events.Vote.createFilter(fromBlock='latest')
+
+
+@pytest.fixture
+def casper_logout_filter(casper):
+    return casper.events.Logout.createFilter(fromBlock='latest')
+
+
+@pytest.fixture
+def casper_withdraw_filter(casper):
+    return casper.events.Withdraw.createFilter(fromBlock='latest')
+
+
+@pytest.fixture
+def casper_slash_filter(casper):
+    return casper.events.Slash.createFilter(fromBlock='latest')
+
+
+@pytest.fixture
+def casper_epoch_filter(casper):
+    return casper.events.Epoch.createFilter(fromBlock='latest')
+
+
+@pytest.fixture
 def casper(w3, tester, casper_abi, casper_address):
     casper = w3.eth.contract(
         address=casper_address,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,12 +18,6 @@ from vyper import (
     utils as vyper_utils,
 )
 
-from ethereum.abi import ContractTranslator
-from ethereum.genesis_helpers import mk_basic_state
-from ethereum.transactions import Transaction
-from ethereum.tools import ethereum_tester
-from ethereum import utils
-
 from utils.valcodes import compile_valcode_to_evm_bytecode
 
 OWN_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -33,9 +27,9 @@ GAS_PRICE = 25 * 10**9
 VYPER_RLP_DECODER_TX_HEX = "0xf9035b808506fc23ac0083045f788080b903486103305660006109ac5260006109cc527f0100000000000000000000000000000000000000000000000000000000000000600035046109ec526000610a0c5260006109005260c06109ec51101515585760f86109ec51101561006e5760bf6109ec510336141558576001610a0c52610098565b60013560f76109ec51036020035260005160f66109ec510301361415585760f66109ec5103610a0c525b61022060016064818352015b36610a0c511015156100b557610291565b7f0100000000000000000000000000000000000000000000000000000000000000610a0c5135046109ec526109cc5160206109ac51026040015260016109ac51016109ac5260806109ec51101561013b5760016109cc5161044001526001610a0c516109cc5161046001376001610a0c5101610a0c5260216109cc51016109cc52610281565b60b86109ec5110156101d15760806109ec51036109cc51610440015260806109ec51036001610a0c51016109cc51610460013760816109ec5114156101ac5760807f01000000000000000000000000000000000000000000000000000000000000006001610a0c5101350410151558575b607f6109ec5103610a0c5101610a0c5260606109ec51036109cc51016109cc52610280565b60c06109ec51101561027d576001610a0c51013560b76109ec510360200352600051610a2c526038610a2c5110157f01000000000000000000000000000000000000000000000000000000000000006001610a0c5101350402155857610a2c516109cc516104400152610a2c5160b66109ec5103610a0c51016109cc516104600137610a2c5160b66109ec5103610a0c510101610a0c526020610a2c51016109cc51016109cc5261027f565bfe5b5b5b81516001018083528114156100a4575b5050601f6109ac511115155857602060206109ac5102016109005260206109005103610a0c5261022060016064818352015b6000610a0c5112156102d45761030a565b61090051610a0c516040015101610a0c51610900516104400301526020610a0c5103610a0c5281516001018083528114156102c3575b50506109cc516109005101610420526109cc5161090051016109005161044003f35b61000461033003610004600039610004610330036000f31b2d4f"  # NOQA
 VYPER_RLP_DECODER_TX_SENDER = "0x39ba083c30fCe59883775Fc729bBE1f9dE4DEe11"
 MSG_HASHER_TX_HEX = "0xf9016d808506fc23ac0083026a508080b9015a6101488061000e6000396101565660007f01000000000000000000000000000000000000000000000000000000000000006000350460f8811215610038576001915061003f565b60f6810391505b508060005b368312156100c8577f01000000000000000000000000000000000000000000000000000000000000008335048391506080811215610087576001840193506100c2565b60b881121561009d57607f8103840193506100c1565b60c08112156100c05760b68103600185013560b783036020035260005101840193505b5b5b50610044565b81810360388112156100f4578060c00160005380836001378060010160002060e052602060e0f3610143565b61010081121561010557600161011b565b6201000081121561011757600261011a565b60035b5b8160005280601f038160f701815382856020378282600101018120610140526020610140f350505b505050505b6000f31b2d4f"  # NOQA
-MSG_HASHER_TX_SENDER = "0xd7a3bd6c9ea32eff147d067f907ae6b22d436f91"
+MSG_HASHER_TX_SENDER = "0xD7a3BD6C9eA32efF147d067f907AE6b22d436F91"
 PURITY_CHECKER_TX_HEX = "0xf90467808506fc23ac00830583c88080b904546104428061000e60003961045056600061033f537c0100000000000000000000000000000000000000000000000000000000600035047f80010000000000000000000000000000000000000030ffff1c0e00000000000060205263a1903eab8114156103f7573659905901600090523660048237600435608052506080513b806020015990590160009052818152602081019050905060a0526080513b600060a0516080513c6080513b8060200260200159905901600090528181526020810190509050610100526080513b806020026020015990590160009052818152602081019050905061016052600060005b602060a05103518212156103c957610100601f8360a051010351066020518160020a161561010a57fe5b80606013151561011e57607f811315610121565b60005b1561014f5780607f036101000a60018460a0510101510482602002610160510152605e8103830192506103b2565b60f18114801561015f5780610164565b60f282145b905080156101725780610177565b60f482145b9050156103aa5760028212151561019e5760606001830360200261010051015112156101a1565b60005b156101bc57607f6001830360200261010051015113156101bf565b60005b156101d157600282036102605261031e565b6004821215156101f057600360018303602002610100510151146101f3565b60005b1561020d57605a6002830360200261010051015114610210565b60005b1561022b57606060038303602002610100510151121561022e565b60005b1561024957607f60038303602002610100510151131561024c565b60005b1561025e57600482036102605261031d565b60028212151561027d57605a6001830360200261010051015114610280565b60005b1561029257600282036102605261031c565b6002821215156102b157609060018303602002610100510151146102b4565b60005b156102c657600282036102605261031b565b6002821215156102e65760806001830360200261010051015112156102e9565b60005b156103035760906001830360200261010051015112610306565b60005b1561031857600282036102605261031a565bfe5b5b5b5b5b604060405990590160009052600081526102605160200261016051015181602001528090502054156103555760016102a052610393565b60306102605160200261010051015114156103755760016102a052610392565b60606102605160200261010051015114156103915760016102a0525b5b5b6102a051151561039f57fe5b6001830192506103b1565b6001830192505b5b8082602002610100510152600182019150506100e0565b50506001604060405990590160009052600081526080518160200152809050205560016102e05260206102e0f35b63c23697a8811415610440573659905901600090523660048237600435608052506040604059905901600090526000815260805181602001528090502054610300526020610300f35b505b6000f31b2d4f"  # NOQA
-PURITY_CHECKER_TX_SENDER = "0xea0f0d55ee82edf248ed648a9a8d213fba8b5081"
+PURITY_CHECKER_TX_SENDER = "0xeA0f0D55EE82Edf248eD648A9A8d213FBa8b5081"
 PURITY_CHECKER_ABI = [{'name': 'check(address)', 'type': 'function', 'constant': True, 'inputs': [{'name': 'addr', 'type': 'address'}], 'outputs': [{'name': 'out', 'type': 'bool'}]}, {'name': 'submit(address)', 'type': 'function', 'constant': False, 'inputs': [{'name': 'addr', 'type': 'address'}], 'outputs': [{'name': 'out', 'type': 'bool'}]}]  # NOQA
 
 EPOCH_LENGTH = 10
@@ -46,22 +40,24 @@ BASE_INTEREST_FACTOR = 0.02
 BASE_PENALTY_FACTOR = 0.002
 MIN_DEPOSIT_SIZE = 1000 * 10**18  # 1000 ether
 
-FUNDED_PRIVKEYS = [ethereum_tester.k1, ethereum_tester.k2, ethereum_tester.k3, ethereum_tester.k4, ethereum_tester.k5]
+# FUNDED_PRIVKEYS = [ethereum_tester.k1, ethereum_tester.k2, ethereum_tester.k3, ethereum_tester.k4, ethereum_tester.k5]
 DEPOSIT_AMOUNTS = [
     2000 * 10**18,
     # 1000 * 10**18,
 ]
 
 
-def next_contract_address(base_tester, fake_contract_code):
+@pytest.fixture
+def next_contract_address(w3, base_tester, fake_contract_code):
     def next_contract_address(sender):
         snapshot_id = base_tester.take_snapshot()
         bytecode = compiler.compile(fake_contract_code)
+        hex_bytecode = Web3.toHex(bytecode)
         tx_hash = w3.eth.sendTransaction({
             'from': sender,
             'to': '',
             'gas': 7000000,
-            'data': bytecode
+            'data': hex_bytecode
         })
         contract_address = w3.eth.getTransactionReceipt(tx_hash).contractAddress
 
@@ -79,7 +75,7 @@ def fake_hash():
 def fake_contract_code():
     return '''
 @public
-def five() -> uint256
+def five() -> int128:
      return 5
 '''
 
@@ -89,19 +85,19 @@ def base_sender(base_tester):
     return base_tester.get_accounts()[-1]
 
 
-@pytest.fixture
-def base_sender_privkey():
-    return tester.k0
+# @pytest.fixture
+# def base_sender_privkey():
+    # return tester.k0
 
 
-@pytest.fixture(params=FUNDED_PRIVKEYS[0:1])
-def funded_privkey(request):
-    return request.param
+# @pytest.fixture(params=FUNDED_PRIVKEYS[0:1])
+# def funded_privkey(request):
+    # return request.param
 
 
-@pytest.fixture
-def funded_privkeys():
-    return FUNDED_PRIVKEYS
+# @pytest.fixture
+# def funded_privkeys():
+    # return FUNDED_PRIVKEYS
 
 
 @pytest.fixture(params=DEPOSIT_AMOUNTS)
@@ -110,53 +106,33 @@ def deposit_amount(request):
 
 
 @pytest.fixture
-def vyper_rlp_decoder_tx():
-    return rlp.hex_decode(VYPER_RLP_DECODER_TX_HEX, Transaction)
+def vyper_rlp_decoder_address():
+    return vyper_utils.RLP_DECODER_ADDRESS
 
 
 @pytest.fixture
-def vyper_rlp_decoder_address(next_contract_address):
-    return next_contract_address(VYPER_RLP_DECODER_TX_SENDER)
-
-
-@pytest.fixture
-def msg_hasher_tx():
-    return rlp.hex_decode(MSG_HASHER_TX_HEX, Transaction)
-
-
-@pytest.fixture
-def msg_hasher_address(base_tester, fake_code):
+def msg_hasher_address(base_tester, deploy_msg_hasher):
     snapshot_id = base_tester.take_snapshot()
-    bytecode = compiler.compile(fake_code)
-    tx_hash = w3.eth.sendTransaction({
-        'from': base_sender,
-        'to': '',
-        'gas': 7000000,
-        'data': bytecode
-    })
-    contract_address = w3.eth.getTransactionReceipt(tx_hash).contractAddress
-
+    address = deploy_msg_hasher()
     base_tester.revert_to_snapshot(snapshot_id)
-    return contract_address
-
-
-
-    return msg_hasher_tx.creates
+    return address
 
 
 @pytest.fixture
-def purity_checker_tx():
-    return rlp.hex_decode(PURITY_CHECKER_TX_HEX, Transaction)
+def purity_checker_address(base_tester, deploy_purity_checker):
+    snapshot_id = base_tester.take_snapshot()
+    address = deploy_purity_checker()
+    base_tester.revert_to_snapshot(snapshot_id)
+    return address
 
 
 @pytest.fixture
-def purity_checker_address(next_contract_address):
-    return next_contract_address(PURITY_CHECKER_TX_SENDER)
-
-
-@pytest.fixture
-def purity_checker_ct():
-    return ContractTranslator(PURITY_CHECKER_ABI)
+def purity_checker(w3, purity_checker_address):
+    purity_checker = w3.eth.contract(
+        address=purity_checker_address,
+        abi=PURITY_CHECKER_ABI
+    )
+    return purity_checker
 
 
 @pytest.fixture
@@ -231,15 +207,63 @@ def zero_gas_price_strategy(web3, transaction_params=None):
     return 0  # zero gas price makes testing simpler.
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def w3(base_tester):
-    w3 = Web3(EthereumTesterProvider(tester))
-    w3.eth.setGasPriceStrategy(zero_gas_price_strategy)
-    return w3
+    web3 = Web3(EthereumTesterProvider(base_tester))
+    web3.eth.setGasPriceStrategy(zero_gas_price_strategy)
+    return web3
 
 
 @pytest.fixture
-def deploy_rlp_decoder(tester, w3):
+def tester(
+        w3,
+        base_tester,
+        casper_args,
+        casper_code,
+        casper_abi,
+        casper_address,
+        deploy_rlp_decoder,
+        deploy_msg_hasher,
+        deploy_purity_checker,
+        base_sender,
+        initialize_contract=True):
+    deploy_rlp_decoder()
+    deploy_msg_hasher()
+    deploy_purity_checker()
+
+    # NOTE: bytecode cannot be compiled before RLP Decoder is deployed to chain
+    # otherwise, vyper compiler cannot properly embed RLP decoder address
+    casper_bytecode = compiler.compile(casper_code)
+
+    # tx_hash = w3.eth.sendTransaction({
+    # 'from': base_sender,
+    # 'to': '',
+    # 'gas': 7000000,
+    # 'data': deploy_code
+    # })
+    # casper_address = w3.eth.getTransactionReceipt(tx_hash).contractAddress
+
+    Casper = w3.eth.contract(abi=casper_abi, bytecode=casper_bytecode)
+    tx_hash = Casper.constructor().transact({'from': base_sender})
+    tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+
+    assert tx_receipt.contractAddress == casper_address
+
+    # Casper contract needs money for its activity
+    w3.eth.sendTransaction({
+        'to': casper_address,
+        'value': 10**21
+    })
+
+    if initialize_contract:
+        casper_contract = casper(w3, base_tester, casper_abi, casper_address)
+        casper_contract.functions.init(*casper_args).transact()
+
+    return tester
+
+
+@pytest.fixture
+def deploy_rlp_decoder(w3):
     def deploy_rlp_decoder():
         w3.eth.sendTransaction({
             'to': VYPER_RLP_DECODER_TX_SENDER,
@@ -251,10 +275,11 @@ def deploy_rlp_decoder(tester, w3):
         contract_address = receipt.contractAddress
         assert vyper_utils.RLP_DECODER_ADDRESS == w3.toInt(hexstr=contract_address)
         return contract_address
+    return deploy_rlp_decoder
 
 
 @pytest.fixture
-def deploy_msg_hasher(tester, w3):
+def deploy_msg_hasher(w3):
     def deploy_msg_hasher():
         w3.eth.sendTransaction({
             'to': MSG_HASHER_TX_SENDER,
@@ -264,93 +289,21 @@ def deploy_msg_hasher(tester, w3):
 
         receipt = w3.eth.getTransactionReceipt(tx_hash)
         return receipt.contractAddress
+    return deploy_msg_hasher
 
 
 @pytest.fixture
-def deploy_purity_checker(tester, w3):
+def deploy_purity_checker(w3):
     def deploy_purity_checker():
         w3.eth.sendTransaction({
             'to': PURITY_CHECKER_TX_SENDER,
             'value': 10**17
         })
-        tx_hash = w3.eth.sendRawTransaction(PURITY_CHECKER_TX_SENDER)
+        tx_hash = w3.eth.sendRawTransaction(PURITY_CHECKER_TX_HEX)
 
         receipt = w3.eth.getTransactionReceipt(tx_hash)
         return receipt.contractAddress
-
-
-@pytest.fixture
-def tester(
-        w3,
-        base_tester,
-        casper_args,
-        casper_code,
-        casper_abi,
-        casper_ct,
-        casper_address,
-        deploy_rlp_decoder,
-        deploy_msg_hasher,
-        deploy_purity_checker,
-        dependency_transactions,
-        msg_hasher_address,
-        purity_checker_address,
-        base_sender,
-        initialize_contract=True):
-    deploy_rlp_decoder()
-    msg_hasher_address = deploy_msg_hasher()
-    purity_checker_address = deploy_purity_checker()
-
-    # NOTE: bytecode cannot be compiled before RLP Decoder is deployed to chain
-    # otherwise, vyper compiler cannot properly embed RLP decoder address
-    casper_bytecode = compiler.compile(casper_code)
-
-    deploy_code = casper_bytecode
-    tx_hash = w3.eth.sendTransaction({
-        'from': base_sender,
-        'to': '',
-        'gas': 7000000,
-        'data': deploy_code
-    })
-    casper_address = w3.eth.getTransactionReceipt(tx_hash).contractAddress
-
-    # Casper contract needs money for its activity
-    w3.eth.sendTransaction({
-        'to': casper_address,
-        'value': 10**21
-    })
-
-    Casper = w3.eth.contract(abi=casper_abi, bytecode=casper_bytecode)
-    tx_hash = Casper.constructor().transact()
-    tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
-
-    assert tx_receipt.contractAddress == casper_address
-
-    if initialize_contract:
-        casper_contract = casper(w3, base_tester, casper_abi, casper_address)
-        casper_contract.functions.init(*casper_args).transact()
-
-    return tester
-
-
-'''
-@pytest.fixture
-def test_chain(alloc=tester.base_alloc, genesis_gas_limit=9999999,
-               min_gas_limit=5000, startgas=3141592):
-    # genesis
-    header = {
-        "number": 0, "gas_limit": genesis_gas_limit,
-        "gas_used": 0, "timestamp": 1467446877, "difficulty": 1,
-        "uncles_hash": '0x'+utils.encode_hex(utils.sha3(rlp.encode([])))
-    }
-    genesis = mk_basic_state(alloc, header, tester.get_env(None))
-    # tester
-    tester.languages['vyper'] = compiler.Compiler()
-    tester.STARTGAS = startgas
-    chain = tester.Chain(alloc=alloc, genesis=genesis)
-    chain.chain.env.config['MIN_GAS_LIMIT'] = min_gas_limit
-    chain.mine(1)
-    return chain
-'''
+    return deploy_purity_checker
 
 
 @pytest.fixture
@@ -362,16 +315,6 @@ def casper_code():
 @pytest.fixture
 def casper_abi(casper_code):
     return compiler.mk_full_signature(casper_code)
-
-
-@pytest.fixture
-def casper_ct(casper_abi):
-    return ContractTranslator(casper_abi)
-
-
-@pytest.fixture
-def dependency_transactions(vyper_rlp_decoder_tx, msg_hasher_tx, purity_checker_tx):
-    return [vyper_rlp_decoder_tx, msg_hasher_tx, purity_checker_tx]
 
 
 @pytest.fixture
@@ -390,22 +333,19 @@ def casper(w3, tester, casper_abi, casper_address):
 
 @pytest.fixture
 def deploy_casper_contract(
-        test_chain,
+        w3,
+        blank_tester,
         casper_code,
-        casper_ct,
         casper_abi,
         casper_address,
-        dependency_transactions,
-        msg_hasher_address,
-        purity_checker_address,
-        base_sender_privkey):
+        base_sender):
     def deploy_casper_contract(contract_args, initialize_contract=True):
-        chain = casper_chain(
-            test_chain, contract_args, casper_code, casper_abi, casper_ct, casper_address,
-            dependency_transactions, msg_hasher_address, purity_checker_address,
-            base_sender_privkey, initialize_contract
+        t = tester(
+            w3, blank_tester, contract_args, casper_code, casper_abi, casper_address,
+            deploy_rlp_decoder, deploy_msg_hasher, deploy_purity_checker,
+            base_sender, initialize_contract
         )
-        return casper(chain, casper_abi, casper_address)
+        return casper(w3, t, casper_abi, casper_address)
     return deploy_casper_contract
 
 

--- a/tests/test_chain_initialization.py
+++ b/tests/test_chain_initialization.py
@@ -9,26 +9,26 @@ def test_rlp_decoding_is_pure(
     assert purity_return_val == 1
 
 
-# def test_msg_hasher_is_pure(
-        # tester,
-        # purity_checker,
-        # msg_hasher_address,
-        # ):
-    # purity_return_val = purity_checker.functions.submit(msg_hasher_address).call()
-    # assert purity_return_val == 1
+def test_msg_hasher_is_pure(
+        tester,
+        purity_checker,
+        msg_hasher_address,
+        ):
+    purity_return_val = purity_checker.functions.submit(msg_hasher_address).call()
+    assert purity_return_val == 1
 
 
 # sanity check on casper contract basic functionality
-# def test_init_first_epoch(tester, casper, new_epoch, warm_up_period, epoch_length):
-    # block_number = tester.get_block_by_number('latest')['block_number']
-    # start_epoch = (block_number + warm_up_period) // epoch_length
+def test_init_first_epoch(tester, concise_casper, new_epoch, warm_up_period, epoch_length):
+    block_number = tester.get_block_by_number('latest')['number']
+    start_epoch = (block_number + warm_up_period) // epoch_length
 
-    # assert casper.current_epoch() == start_epoch
-    # assert casper.next_validator_index() == 1
+    assert concise_casper.current_epoch() == start_epoch
+    assert concise_casper.next_validator_index() == 1
 
-    # new_epoch()
+    new_epoch()
 
-    # assert casper.dynasty() == 0
-    # assert casper.next_validator_index() == 1
-    # assert casper.current_epoch() == start_epoch + 1
-    # assert casper.total_slashed(casper.current_epoch()) == 0
+    assert concise_casper.dynasty() == 0
+    assert concise_casper.next_validator_index() == 1
+    assert concise_casper.current_epoch() == start_epoch + 1
+    assert concise_casper.total_slashed(concise_casper.current_epoch()) == 0

--- a/tests/test_chain_initialization.py
+++ b/tests/test_chain_initialization.py
@@ -1,48 +1,34 @@
-from ethereum import utils
 
 
 def test_rlp_decoding_is_pure(
-        casper_chain,
-        base_sender_privkey,
-        vyper_rlp_decoder_address,
-        purity_checker_address,
-        purity_checker_ct
+        tester,
+        purity_checker,
+        vyper_rlp_decoder_address
         ):
-    purity_return_val = casper_chain.tx(
-        base_sender_privkey,
-        purity_checker_address,
-        0,
-        purity_checker_ct.encode('submit', [vyper_rlp_decoder_address])
-    )
-    assert utils.big_endian_to_int(purity_return_val) == 1
+    purity_return_val = purity_checker.functions.submit(vyper_rlp_decoder_address).call()
+    assert purity_return_val == 1
 
 
-def test_msg_hasher_is_pure(
-        casper_chain,
-        base_sender_privkey,
-        msg_hasher_address,
-        purity_checker_address,
-        purity_checker_ct
-        ):
-    purity_return_val = casper_chain.tx(
-        base_sender_privkey,
-        purity_checker_address,
-        0,
-        purity_checker_ct.encode('submit', [msg_hasher_address])
-    )
-    assert utils.big_endian_to_int(purity_return_val) == 1
+# def test_msg_hasher_is_pure(
+        # tester,
+        # purity_checker,
+        # msg_hasher_address,
+        # ):
+    # purity_return_val = purity_checker.functions.submit(msg_hasher_address).call()
+    # assert purity_return_val == 1
 
 
 # sanity check on casper contract basic functionality
-def test_init_first_epoch(casper_chain, casper, new_epoch, warm_up_period, epoch_length):
-    start_epoch = (casper_chain.head_state.block_number + warm_up_period) // epoch_length
+# def test_init_first_epoch(tester, casper, new_epoch, warm_up_period, epoch_length):
+    # block_number = tester.get_block_by_number('latest')['block_number']
+    # start_epoch = (block_number + warm_up_period) // epoch_length
 
-    assert casper.current_epoch() == start_epoch
-    assert casper.next_validator_index() == 1
+    # assert casper.current_epoch() == start_epoch
+    # assert casper.next_validator_index() == 1
 
-    new_epoch()
+    # new_epoch()
 
-    assert casper.dynasty() == 0
-    assert casper.next_validator_index() == 1
-    assert casper.current_epoch() == start_epoch + 1
-    assert casper.total_slashed(casper.current_epoch()) == 0
+    # assert casper.dynasty() == 0
+    # assert casper.next_validator_index() == 1
+    # assert casper.current_epoch() == start_epoch + 1
+    # assert casper.total_slashed(casper.current_epoch()) == 0

--- a/tests/test_fork_choice_helpers.py
+++ b/tests/test_fork_choice_helpers.py
@@ -11,14 +11,20 @@ import pytest
         (6, int(2e30))
     ]
 )
-def test_default_highest_justified_epoch(test_chain, start_epoch, min_deposits, epoch_length,
-                                         casper_args, deploy_casper_contract):
-    test_chain.mine(
-        epoch_length * start_epoch - test_chain.head_state.block_number
+def test_default_highest_justified_epoch(
+        base_tester,
+        start_epoch,
+        min_deposits,
+        epoch_length,
+        casper_args,
+        deploy_casper_contract):
+    block_number = base_tester.get_block_by_number('latest')['number']
+    base_tester.mine_blocks(
+        epoch_length * start_epoch - block_number
     )
     casper = deploy_casper_contract(casper_args)
 
-    assert casper.highest_justified_epoch(min_deposits) == 0
+    assert casper.functions.highest_justified_epoch(min_deposits).call() == 0
 
 
 @pytest.mark.parametrize(
@@ -31,11 +37,14 @@ def test_default_highest_justified_epoch(test_chain, start_epoch, min_deposits, 
         (int(2e30))
     ]
 )
-def test_highest_justified_epoch_no_validators(casper, new_epoch, min_deposits):
+def test_highest_justified_epoch_no_validators(
+        concise_casper,
+        new_epoch,
+        min_deposits):
     for i in range(5):
-        highest_justified_epoch = casper.highest_justified_epoch(min_deposits)
+        highest_justified_epoch = concise_casper.highest_justified_epoch(min_deposits)
         if min_deposits == 0:
-            assert highest_justified_epoch == casper.last_justified_epoch()
+            assert highest_justified_epoch == concise_casper.last_justified_epoch()
         else:
             assert highest_justified_epoch == 0
 
@@ -43,23 +52,32 @@ def test_highest_justified_epoch_no_validators(casper, new_epoch, min_deposits):
 
 
 @pytest.mark.parametrize(
-    'start_epoch,min_deposits',
+    'start_epoch,min_deposits,warm_up_period',
     [
-        (2, 0),
-        (3, 1),
-        (0, int(1e4)),
-        (7, int(4e10)),
-        (6, int(2e30))
+        (2, 0, 0),
+        (3, 1, 0),
+        (0, int(1e4), 0),
+        (7, int(4e10), 0),
+        (6, int(2e30), 0),
     ]
 )
-def test_default_highest_finalized_epoch(test_chain, start_epoch, min_deposits, epoch_length,
-                                         casper_args, deploy_casper_contract):
-    test_chain.mine(
-        epoch_length * start_epoch - test_chain.head_state.block_number
+def test_default_highest_finalized_epoch(
+        base_tester,
+        start_epoch,
+        min_deposits,
+        warm_up_period,
+        epoch_length,
+        casper_args,
+        deploy_casper_contract):
+
+    block_number = base_tester.get_block_by_number('latest')['number']
+    base_tester.mine_blocks(
+        max(epoch_length * start_epoch - block_number - 2, 0)
     )
     casper = deploy_casper_contract(casper_args)
 
-    assert casper.highest_finalized_epoch(min_deposits) == -1
+    assert casper.functions.START_EPOCH().call() == start_epoch
+    assert casper.functions.highest_finalized_epoch(min_deposits).call() == -1
 
 
 @pytest.mark.parametrize(
@@ -72,145 +90,164 @@ def test_default_highest_finalized_epoch(test_chain, start_epoch, min_deposits, 
         (int(2e30))
     ]
 )
-def test_highest_finalized_epoch_no_validators(casper, new_epoch, min_deposits):
+def test_highest_finalized_epoch_no_validators(concise_casper, new_epoch, min_deposits):
     for i in range(5):
-        highest_finalized_epoch = casper.highest_finalized_epoch(min_deposits)
+        highest_finalized_epoch = concise_casper.highest_finalized_epoch(min_deposits)
         if min_deposits > 0:
             expected_epoch = -1
         else:
-            if casper.current_epoch() == casper.START_EPOCH():
+            if concise_casper.current_epoch() == concise_casper.START_EPOCH():
                 expected_epoch = -1
             else:
-                expected_epoch = casper.last_finalized_epoch()
+                expected_epoch = concise_casper.last_finalized_epoch()
 
         assert highest_finalized_epoch == expected_epoch
 
         new_epoch()
 
 
-def test_highest_justified_and_epoch(casper, funded_privkey, deposit_amount,
-                                     new_epoch, induct_validator, mk_suggested_vote):
-    start_epoch = casper.START_EPOCH()
-    validator_index = induct_validator(funded_privkey, deposit_amount)
+def test_highest_justified_and_epoch(
+        casper,
+        concise_casper,
+        funded_account,
+        validation_key,
+        deposit_amount,
+        new_epoch,
+        induct_validator,
+        mk_suggested_vote):
+    start_epoch = concise_casper.START_EPOCH()
+    validator_index = induct_validator(funded_account, validation_key, deposit_amount)
     higher_deposit = int(deposit_amount * 1.1)
 
-    assert casper.total_curdyn_deposits_in_wei() == deposit_amount
-    assert casper.current_epoch() == start_epoch + 3  # 3 to induct first dynasty
+    assert concise_casper.total_curdyn_deposits_in_wei() == deposit_amount
+    assert concise_casper.current_epoch() == start_epoch + 3  # 3 to induct first dynasty
 
-    assert casper.highest_justified_epoch(deposit_amount) == 0
-    assert casper.highest_finalized_epoch(deposit_amount) == -1
-    assert casper.highest_justified_epoch(0) == start_epoch + 2
-    assert casper.highest_finalized_epoch(0) == start_epoch + 2
-    assert casper.highest_justified_epoch(higher_deposit) == 0
-    assert casper.highest_finalized_epoch(higher_deposit) == -1
+    assert concise_casper.highest_justified_epoch(deposit_amount) == 0
+    assert concise_casper.highest_finalized_epoch(deposit_amount) == -1
+    assert concise_casper.highest_justified_epoch(0) == start_epoch + 2
+    assert concise_casper.highest_finalized_epoch(0) == start_epoch + 2
+    assert concise_casper.highest_justified_epoch(higher_deposit) == 0
+    assert concise_casper.highest_finalized_epoch(higher_deposit) == -1
 
     # justify current_epoch in contract
-    casper.vote(mk_suggested_vote(validator_index, funded_privkey))
+    casper.functions.vote(
+        mk_suggested_vote(validator_index, validation_key)
+    ).transact()
 
-    assert casper.checkpoints__cur_dyn_deposits(start_epoch + 3) == 0
-    assert casper.checkpoints__prev_dyn_deposits(start_epoch + 3) == 0
-    assert casper.last_justified_epoch() == start_epoch + 3
-    assert casper.last_finalized_epoch() == start_epoch + 2
+    assert concise_casper.checkpoints__cur_dyn_deposits(start_epoch + 3) == 0
+    assert concise_casper.checkpoints__prev_dyn_deposits(start_epoch + 3) == 0
+    assert concise_casper.last_justified_epoch() == start_epoch + 3
+    assert concise_casper.last_finalized_epoch() == start_epoch + 2
 
-    assert casper.highest_justified_epoch(deposit_amount) == 0
-    assert casper.highest_finalized_epoch(deposit_amount) == -1
-    assert casper.highest_justified_epoch(0) == start_epoch + 3
-    assert casper.highest_finalized_epoch(0) == start_epoch + 2
-    assert casper.highest_justified_epoch(higher_deposit) == 0
-    assert casper.highest_finalized_epoch(higher_deposit) == -1
-
-    new_epoch()
-    casper.vote(mk_suggested_vote(validator_index, funded_privkey))
-
-    assert casper.checkpoints__cur_dyn_deposits(start_epoch + 4) == deposit_amount
-    assert casper.checkpoints__prev_dyn_deposits(start_epoch + 4) == 0
-    assert casper.last_justified_epoch() == start_epoch + 4
-    assert casper.last_finalized_epoch() == start_epoch + 3
-
-    assert casper.highest_justified_epoch(deposit_amount) == 0
-    assert casper.highest_finalized_epoch(deposit_amount) == -1
-    assert casper.highest_justified_epoch(0) == start_epoch + 4
-    assert casper.highest_finalized_epoch(0) == start_epoch + 3
-    assert casper.highest_justified_epoch(higher_deposit) == 0
-    assert casper.highest_finalized_epoch(higher_deposit) == -1
+    assert concise_casper.highest_justified_epoch(deposit_amount) == 0
+    assert concise_casper.highest_finalized_epoch(deposit_amount) == -1
+    assert concise_casper.highest_justified_epoch(0) == start_epoch + 3
+    assert concise_casper.highest_finalized_epoch(0) == start_epoch + 2
+    assert concise_casper.highest_justified_epoch(higher_deposit) == 0
+    assert concise_casper.highest_finalized_epoch(higher_deposit) == -1
 
     new_epoch()
-    casper.vote(mk_suggested_vote(validator_index, funded_privkey))
+    casper.functions.vote(
+        mk_suggested_vote(validator_index, validation_key)
+    ).transact()
 
-    assert casper.checkpoints__cur_dyn_deposits(start_epoch + 5) == deposit_amount
-    assert casper.checkpoints__prev_dyn_deposits(start_epoch + 5) == deposit_amount
-    assert casper.last_justified_epoch() == start_epoch + 5
-    assert casper.last_finalized_epoch() == start_epoch + 4
+    assert concise_casper.checkpoints__cur_dyn_deposits(start_epoch + 4) == deposit_amount
+    assert concise_casper.checkpoints__prev_dyn_deposits(start_epoch + 4) == 0
+    assert concise_casper.last_justified_epoch() == start_epoch + 4
+    assert concise_casper.last_finalized_epoch() == start_epoch + 3
+
+    assert concise_casper.highest_justified_epoch(deposit_amount) == 0
+    assert concise_casper.highest_finalized_epoch(deposit_amount) == -1
+    assert concise_casper.highest_justified_epoch(0) == start_epoch + 4
+    assert concise_casper.highest_finalized_epoch(0) == start_epoch + 3
+    assert concise_casper.highest_justified_epoch(higher_deposit) == 0
+    assert concise_casper.highest_finalized_epoch(higher_deposit) == -1
+
+    new_epoch()
+    casper.functions.vote(
+        mk_suggested_vote(validator_index, validation_key)
+    ).transact()
+
+    assert concise_casper.checkpoints__cur_dyn_deposits(start_epoch + 5) == deposit_amount
+    assert concise_casper.checkpoints__prev_dyn_deposits(start_epoch + 5) == deposit_amount
+    assert concise_casper.last_justified_epoch() == start_epoch + 5
+    assert concise_casper.last_finalized_epoch() == start_epoch + 4
 
     # enough prev and cur deposits in checkpoint 5 for the justified block
-    assert casper.highest_justified_epoch(deposit_amount) == start_epoch + 5
+    assert concise_casper.highest_justified_epoch(deposit_amount) == start_epoch + 5
     # not enough prev and cur deposits in checkpoint 4 for the finalized block
-    assert casper.highest_finalized_epoch(deposit_amount) == -1
-    assert casper.highest_justified_epoch(0) == start_epoch + 5
-    assert casper.highest_finalized_epoch(0) == start_epoch + 4
-    assert casper.highest_justified_epoch(higher_deposit) == 0
-    assert casper.highest_finalized_epoch(higher_deposit) == -1
+    assert concise_casper.highest_finalized_epoch(deposit_amount) == -1
+    assert concise_casper.highest_justified_epoch(0) == start_epoch + 5
+    assert concise_casper.highest_finalized_epoch(0) == start_epoch + 4
+    assert concise_casper.highest_justified_epoch(higher_deposit) == 0
+    assert concise_casper.highest_finalized_epoch(higher_deposit) == -1
 
     new_epoch()
-    casper.vote(mk_suggested_vote(validator_index, funded_privkey))
+    casper.functions.vote(
+        mk_suggested_vote(validator_index, validation_key)
+    ).transact()
 
-    assert casper.checkpoints__cur_dyn_deposits(start_epoch + 6) > deposit_amount
-    assert casper.checkpoints__prev_dyn_deposits(start_epoch + 6) > deposit_amount
-    assert casper.last_justified_epoch() == start_epoch + 6
-    assert casper.last_finalized_epoch() == start_epoch + 5
+    assert concise_casper.checkpoints__cur_dyn_deposits(start_epoch + 6) > deposit_amount
+    assert concise_casper.checkpoints__prev_dyn_deposits(start_epoch + 6) > deposit_amount
+    assert concise_casper.last_justified_epoch() == start_epoch + 6
+    assert concise_casper.last_finalized_epoch() == start_epoch + 5
 
     # enough deposits in checkpoint 6 for justified and checkpoint 5 for finalized!
-    assert casper.highest_justified_epoch(deposit_amount) == start_epoch + 6
-    assert casper.highest_finalized_epoch(deposit_amount) == start_epoch + 5
-    assert casper.highest_justified_epoch(higher_deposit) == 0
-    assert casper.highest_finalized_epoch(higher_deposit) == -1
-    assert casper.highest_justified_epoch(0) == start_epoch + 6
-    assert casper.highest_finalized_epoch(0) == start_epoch + 5
+    assert concise_casper.highest_justified_epoch(deposit_amount) == start_epoch + 6
+    assert concise_casper.highest_finalized_epoch(deposit_amount) == start_epoch + 5
+    assert concise_casper.highest_justified_epoch(higher_deposit) == 0
+    assert concise_casper.highest_finalized_epoch(higher_deposit) == -1
+    assert concise_casper.highest_justified_epoch(0) == start_epoch + 6
+    assert concise_casper.highest_finalized_epoch(0) == start_epoch + 5
 
     new_epoch()
     # no vote
 
-    assert casper.checkpoints__cur_dyn_deposits(start_epoch + 7) > deposit_amount
-    assert casper.checkpoints__prev_dyn_deposits(start_epoch + 7) > deposit_amount
-    assert casper.last_justified_epoch() == start_epoch + 6
-    assert casper.last_finalized_epoch() == start_epoch + 5
+    assert concise_casper.checkpoints__cur_dyn_deposits(start_epoch + 7) > deposit_amount
+    assert concise_casper.checkpoints__prev_dyn_deposits(start_epoch + 7) > deposit_amount
+    assert concise_casper.last_justified_epoch() == start_epoch + 6
+    assert concise_casper.last_finalized_epoch() == start_epoch + 5
 
-    assert casper.highest_justified_epoch(deposit_amount) == start_epoch + 6
-    assert casper.highest_finalized_epoch(deposit_amount) == start_epoch + 5
-    assert casper.highest_justified_epoch(0) == start_epoch + 6
-    assert casper.highest_finalized_epoch(0) == start_epoch + 5
-    assert casper.highest_justified_epoch(higher_deposit) == 0
-    assert casper.highest_finalized_epoch(higher_deposit) == -1
+    assert concise_casper.highest_justified_epoch(deposit_amount) == start_epoch + 6
+    assert concise_casper.highest_finalized_epoch(deposit_amount) == start_epoch + 5
+    assert concise_casper.highest_justified_epoch(0) == start_epoch + 6
+    assert concise_casper.highest_finalized_epoch(0) == start_epoch + 5
+    assert concise_casper.highest_justified_epoch(higher_deposit) == 0
+    assert concise_casper.highest_finalized_epoch(higher_deposit) == -1
 
     new_epoch()
-    casper.vote(mk_suggested_vote(validator_index, funded_privkey))
+    casper.functions.vote(
+        mk_suggested_vote(validator_index, validation_key)
+    ).transact()
 
-    assert casper.checkpoints__cur_dyn_deposits(start_epoch + 8) > deposit_amount
-    assert casper.checkpoints__prev_dyn_deposits(start_epoch + 8) > deposit_amount
+    assert concise_casper.checkpoints__cur_dyn_deposits(start_epoch + 8) > deposit_amount
+    assert concise_casper.checkpoints__prev_dyn_deposits(start_epoch + 8) > deposit_amount
     # new justified
-    assert casper.last_justified_epoch() == start_epoch + 8
+    assert concise_casper.last_justified_epoch() == start_epoch + 8
     # no new finalized because not sequential justified blocks
-    assert casper.last_finalized_epoch() == start_epoch + 5
+    assert concise_casper.last_finalized_epoch() == start_epoch + 5
 
-    assert casper.highest_justified_epoch(deposit_amount) == start_epoch + 8
-    assert casper.highest_finalized_epoch(deposit_amount) == start_epoch + 5
-    assert casper.highest_justified_epoch(0) == start_epoch + 8
-    assert casper.highest_finalized_epoch(0) == start_epoch + 5
-    assert casper.highest_justified_epoch(higher_deposit) == 0
-    assert casper.highest_finalized_epoch(higher_deposit) == -1
+    assert concise_casper.highest_justified_epoch(deposit_amount) == start_epoch + 8
+    assert concise_casper.highest_finalized_epoch(deposit_amount) == start_epoch + 5
+    assert concise_casper.highest_justified_epoch(0) == start_epoch + 8
+    assert concise_casper.highest_finalized_epoch(0) == start_epoch + 5
+    assert concise_casper.highest_justified_epoch(higher_deposit) == 0
+    assert concise_casper.highest_finalized_epoch(higher_deposit) == -1
 
     new_epoch()
-    casper.vote(mk_suggested_vote(validator_index, funded_privkey))
+    casper.functions.vote(
+        mk_suggested_vote(validator_index, validation_key)
+    ).transact()
 
-    assert casper.checkpoints__cur_dyn_deposits(9) > deposit_amount
-    assert casper.checkpoints__prev_dyn_deposits(9) > deposit_amount
+    assert concise_casper.checkpoints__cur_dyn_deposits(9) > deposit_amount
+    assert concise_casper.checkpoints__prev_dyn_deposits(9) > deposit_amount
     # new justified and finalized because sequential justified blocks
-    assert casper.last_justified_epoch() == start_epoch + 9
-    assert casper.last_finalized_epoch() == start_epoch + 8
+    assert concise_casper.last_justified_epoch() == start_epoch + 9
+    assert concise_casper.last_finalized_epoch() == start_epoch + 8
 
-    assert casper.highest_justified_epoch(deposit_amount) == start_epoch + 9
-    assert casper.highest_finalized_epoch(deposit_amount) == start_epoch + 8
-    assert casper.highest_justified_epoch(0) == start_epoch + 9
-    assert casper.highest_finalized_epoch(0) == start_epoch + 8
-    assert casper.highest_justified_epoch(higher_deposit) == 0
-    assert casper.highest_finalized_epoch(higher_deposit) == -1
+    assert concise_casper.highest_justified_epoch(deposit_amount) == start_epoch + 9
+    assert concise_casper.highest_finalized_epoch(deposit_amount) == start_epoch + 8
+    assert concise_casper.highest_justified_epoch(0) == start_epoch + 9
+    assert concise_casper.highest_finalized_epoch(0) == start_epoch + 8
+    assert concise_casper.highest_justified_epoch(higher_deposit) == 0
+    assert concise_casper.highest_finalized_epoch(higher_deposit) == -1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,15 +1,18 @@
 import pytest
 
-from ethereum.tools.tester import TransactionFailed
+from decimal import Decimal
 
 
-def test_no_double_init(casper_args,
-                        deploy_casper_contract,
-                        assert_tx_failed):
+def test_no_double_init(
+        casper_args,
+        deploy_casper_contract,
+        assert_tx_failed):
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
 
-    casper.init(*casper_args)
-    assert_tx_failed(lambda: casper.init(*casper_args))
+    casper.functions.init(*casper_args).transact()
+    assert_tx_failed(
+        lambda: casper.functions.init(*casper_args).transact()
+    )
 
 
 @pytest.mark.parametrize(
@@ -25,17 +28,25 @@ def test_no_double_init(casper_args,
         (10, 500, 25, 30)
     ]
 )
-def test_start_epoch(test_chain, deploy_epoch, warm_up_period, expected_start_epoch,
-                     epoch_length, casper_args, casper_config, deploy_casper_contract):
-    test_chain.mine(
-        epoch_length * deploy_epoch - test_chain.head_state.block_number
+def test_start_epoch(
+        base_tester,
+        deploy_epoch,
+        warm_up_period,
+        expected_start_epoch,
+        epoch_length,
+        casper_args,
+        casper_config,
+        deploy_casper_contract):
+    block_number = base_tester.get_block_by_number('latest')['number']
+    base_tester.mine_blocks(
+        max(epoch_length * deploy_epoch - block_number - 1, 0)
     )
 
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
-    casper.init(*casper_args)
+    casper.functions.init(*casper_args).transact()
 
-    assert casper.START_EPOCH() == expected_start_epoch
-    assert casper.current_epoch() == expected_start_epoch
+    assert casper.functions.START_EPOCH().call() == expected_start_epoch
+    assert casper.functions.current_epoch().call() == expected_start_epoch
 
 
 @pytest.mark.parametrize(
@@ -49,16 +60,22 @@ def test_start_epoch(test_chain, deploy_epoch, warm_up_period, expected_start_ep
         (500, False),
     ]
 )
-def test_init_epoch_length(epoch_length, success, casper_args,
-                           deploy_casper_contract, assert_tx_failed):
+def test_init_epoch_length(
+        epoch_length,
+        success,
+        casper_args,
+        deploy_casper_contract,
+        assert_tx_failed):
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
 
     if not success:
-        assert_tx_failed(lambda: casper.init(*casper_args))
+        assert_tx_failed(
+            lambda: casper.functions.init(*casper_args).transact()
+        )
         return
 
-    casper.init(*casper_args)
-    assert casper.EPOCH_LENGTH() == epoch_length
+    casper.functions.init(*casper_args).transact()
+    assert casper.functions.EPOCH_LENGTH().call() == epoch_length
 
 
 @pytest.mark.parametrize(
@@ -71,16 +88,22 @@ def test_init_epoch_length(epoch_length, success, casper_args,
         (50000, True),
     ]
 )
-def test_init_warm_up_period(warm_up_period, success, casper_args,
-                             deploy_casper_contract, assert_tx_failed):
+def test_init_warm_up_period(
+        warm_up_period,
+        success,
+        casper_args,
+        deploy_casper_contract,
+        assert_tx_failed):
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
 
     if not success:
-        assert_tx_failed(lambda: casper.init(*casper_args))
+        assert_tx_failed(
+            lambda: casper.functions.init(*casper_args).transact()
+        )
         return
 
-    casper.init(*casper_args)
-    assert casper.WARM_UP_PERIOD() == warm_up_period
+    casper.functions.init(*casper_args).transact()
+    assert casper.functions.WARM_UP_PERIOD().call() == warm_up_period
 
 
 @pytest.mark.parametrize(
@@ -95,16 +118,22 @@ def test_init_warm_up_period(warm_up_period, success, casper_args,
         (500000000, True),
     ]
 )
-def test_init_withdrawal_delay(withdrawal_delay, success, casper_args,
-                               deploy_casper_contract, assert_tx_failed):
+def test_init_withdrawal_delay(
+        withdrawal_delay,
+        success,
+        casper_args,
+        deploy_casper_contract,
+        assert_tx_failed):
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
 
     if not success:
-        assert_tx_failed(lambda: casper.init(*casper_args))
+        assert_tx_failed(
+            lambda: casper.functions.init(*casper_args).transact()
+        )
         return
 
-    casper.init(*casper_args)
-    assert casper.WITHDRAWAL_DELAY() == withdrawal_delay
+    casper.functions.init(*casper_args).transact()
+    assert casper.functions.WITHDRAWAL_DELAY().call() == withdrawal_delay
 
 
 @pytest.mark.parametrize(
@@ -120,62 +149,80 @@ def test_init_withdrawal_delay(withdrawal_delay, success, casper_args,
         (3000000, True),
     ]
 )
-def test_init_dynasty_logout_delay(dynasty_logout_delay, success, casper_args,
-                                   deploy_casper_contract, assert_tx_failed):
+def test_init_dynasty_logout_delay(
+        dynasty_logout_delay,
+        success,
+        casper_args,
+        deploy_casper_contract,
+        assert_tx_failed):
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
 
     if not success:
-        assert_tx_failed(lambda: casper.init(*casper_args))
+        assert_tx_failed(
+            lambda: casper.functions.init(*casper_args).transact()
+        )
         return
 
-    casper.init(*casper_args)
-    assert casper.DYNASTY_LOGOUT_DELAY() == dynasty_logout_delay
+    casper.functions.init(*casper_args).transact()
+    assert casper.functions.DYNASTY_LOGOUT_DELAY().call() == dynasty_logout_delay
 
 
 @pytest.mark.parametrize(
     'base_interest_factor, success',
     [
         (-10, False),
-        (-0.001, False),
+        (Decimal('-0.001'), False),
         (0, True),
-        (7e-3, True),
-        (0.1, True),
-        (1.5, True),
+        (Decimal('7e-3'), True),
+        (Decimal('0.1'), True),
+        (Decimal('1.5'), True),
     ]
 )
-def test_init_base_interest_factor(base_interest_factor, success, casper_args,
-                                   deploy_casper_contract, assert_tx_failed):
+def test_init_base_interest_factor(
+        base_interest_factor,
+        success,
+        casper_args,
+        deploy_casper_contract,
+        assert_tx_failed):
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
 
     if not success:
-        assert_tx_failed(lambda: casper.init(*casper_args))
+        assert_tx_failed(
+            lambda: casper.functions.init(*casper_args).transact()
+        )
         return
 
-    casper.init(*casper_args)
-    assert casper.BASE_INTEREST_FACTOR() == base_interest_factor
+    casper.functions.init(*casper_args).transact()
+    assert casper.functions.BASE_INTEREST_FACTOR().call() == base_interest_factor
 
 
 @pytest.mark.parametrize(
     'base_penalty_factor, success',
     [
         (-10, False),
-        (-0.001, False),
+        (Decimal('-0.001'), False),
         (0, True),
-        (7e-3, True),
-        (0.1, True),
-        (1.5, True),
+        (Decimal('7e-3'), True),
+        (Decimal('0.1'), True),
+        (Decimal('1.5'), True),
     ]
 )
-def test_init_base_penalty_factor(base_penalty_factor, success, casper_args,
-                                  deploy_casper_contract, assert_tx_failed):
+def test_init_base_penalty_factor(
+        base_penalty_factor,
+        success,
+        casper_args,
+        deploy_casper_contract,
+        assert_tx_failed):
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
 
     if not success:
-        assert_tx_failed(lambda: casper.init(*casper_args))
+        assert_tx_failed(
+            lambda: casper.functions.init(*casper_args).transact()
+        )
         return
 
-    casper.init(*casper_args)
-    assert casper.BASE_PENALTY_FACTOR() == base_penalty_factor
+    casper.functions.init(*casper_args).transact()
+    assert casper.functions.BASE_PENALTY_FACTOR().call() == base_penalty_factor
 
 
 @pytest.mark.parametrize(
@@ -191,13 +238,19 @@ def test_init_base_penalty_factor(base_penalty_factor, success, casper_args,
         (int(5e30), True),
     ]
 )
-def test_init_min_deposit_size(min_deposit_size, success, casper_args,
-                               deploy_casper_contract, assert_tx_failed):
+def test_init_min_deposit_size(
+        min_deposit_size,
+        success,
+        casper_args,
+        deploy_casper_contract,
+        assert_tx_failed):
     casper = deploy_casper_contract(casper_args, initialize_contract=False)
 
     if not success:
-        assert_tx_failed(lambda: casper.init(*casper_args))
+        assert_tx_failed(
+            lambda: casper.functions.init(*casper_args).transact()
+        )
         return
 
-    casper.init(*casper_args)
-    assert casper.MIN_DEPOSIT_SIZE() == min_deposit_size
+    casper.functions.init(*casper_args).transact()
+    assert casper.functions.MIN_DEPOSIT_SIZE().call() == min_deposit_size

--- a/tests/test_initialize_epoch.py
+++ b/tests/test_initialize_epoch.py
@@ -1,5 +1,9 @@
 import pytest
 
+from web3 import (
+    Web3,
+)
+
 
 # ensure that our fixture 'new_epoch' functions properly
 @pytest.mark.parametrize(
@@ -11,10 +15,10 @@ import pytest
         (220, 20),
     ]
 )
-def test_new_epoch_fixture(casper_chain, casper, new_epoch, warm_up_period, epoch_length):
+def test_new_epoch_fixture(tester, concise_casper, new_epoch, warm_up_period, epoch_length):
     for i in range(4):
-        prev_epoch = casper.current_epoch()
-        prev_block_number = casper_chain.head_state.block_number
+        prev_epoch = concise_casper.current_epoch()
+        prev_block_number = tester.get_block_by_number('latest')['number']
         if i == 0:
             expected_jump = warm_up_period
             expected_jump += epoch_length - (prev_block_number + warm_up_period) % epoch_length
@@ -22,30 +26,32 @@ def test_new_epoch_fixture(casper_chain, casper, new_epoch, warm_up_period, epoc
             expected_jump = epoch_length - (prev_block_number % epoch_length)
 
         new_epoch()
+        block_number = tester.get_block_by_number('latest')['number']
 
-        block_number = casper_chain.head_state.block_number
-        assert casper.current_epoch() == prev_epoch + 1
-        assert block_number == prev_block_number + expected_jump
-        assert (block_number % epoch_length) == 0
+        assert concise_casper.current_epoch() == prev_epoch + 1
+
+        # +1 because intialize_epoch is mined to take effect
+        assert block_number == prev_block_number + expected_jump + 1
+        # should be 1 block past the initialize_epoch block
+        assert (block_number % epoch_length) == 1
 
 
-def test_epoch_length_range(casper_chain, casper, new_epoch, assert_tx_failed):
-    epoch_length = casper.EPOCH_LENGTH()
-
+def test_epoch_length_range(tester, casper, new_epoch, epoch_length, assert_tx_failed):
     new_epoch()
 
     for _ in range(epoch_length * 3):   # check the entire range 3 times
-        casper_chain.mine(1)
-        block_number = casper_chain.head_state.block_number
-        is_epoch_block = (block_number % epoch_length) == 0
-        next_epoch = casper.current_epoch() + 1
-        if is_epoch_block:
-            casper.initialize_epoch(next_epoch)
-            assert casper.current_epoch() == next_epoch
+        block_number = tester.get_block_by_number('latest')['number']
+
+        next_is_init_block = (block_number + 1) % epoch_length == 0
+        next_epoch = casper.functions.current_epoch().call() + 1
+        if next_is_init_block:
+            casper.functions.initialize_epoch(next_epoch).transact()
+            assert casper.functions.current_epoch().call() == next_epoch
         else:
             assert_tx_failed(
-                lambda: casper.initialize_epoch(next_epoch)
+                lambda: casper.functions.initialize_epoch(next_epoch).transact()
             )
+            tester.mine_block()
 
 
 @pytest.mark.parametrize(
@@ -57,166 +63,211 @@ def test_epoch_length_range(casper_chain, casper, new_epoch, assert_tx_failed):
         (220, 20),
     ]
 )
-def test_cannot_initialize_during_warm_up(casper_chain, casper,
-                                          epoch_length, warm_up_period, assert_tx_failed):
-    assert casper.current_epoch() == \
-        (casper_chain.head_state.block_number + warm_up_period) // epoch_length
+def test_cannot_initialize_during_warm_up(
+        tester,
+        casper,
+        epoch_length,
+        warm_up_period,
+        assert_tx_failed):
 
-    next_epoch = casper.current_epoch() + 1
-    for _ in range(warm_up_period):
+    block_number = tester.get_block_by_number('latest')['number']
+    current_epoch = casper.functions.current_epoch().call()
+    assert current_epoch == (block_number + warm_up_period) // epoch_length
+
+    next_epoch = current_epoch + 1
+    # -1 because the block that called 'init' counts toward warm_up_period
+    for _ in range(warm_up_period - 1):
         # check then mine to ensure that the start block counts
         assert_tx_failed(
-            lambda: casper.initialize_epoch(next_epoch)
+            lambda: casper.functions.initialize_epoch(next_epoch).transact()
         )
-        casper_chain.mine(1)
+        tester.mine_block()
 
     # mine right up until the start of the next epoch
-    blocks_until_next_start = epoch_length - casper_chain.head_state.block_number % epoch_length
+    next_block_number = tester.get_block_by_number('latest')['number'] + 1
+    blocks_until_next_start = epoch_length - next_block_number % epoch_length
     for _ in range(blocks_until_next_start):
         assert_tx_failed(
-            lambda: casper.initialize_epoch(next_epoch)
+            lambda: casper.functions.initialize_epoch(next_epoch).transact()
         )
-        casper_chain.mine(1)
+        tester.mine_block()
 
+    next_block_number = tester.get_block_by_number('latest')['number'] + 1
+    assert next_block_number % epoch_length == 0
     # at start of next_epoch
-    casper.initialize_epoch(next_epoch)
-    assert casper.current_epoch() == next_epoch
+    casper.functions.initialize_epoch(next_epoch).transact()
+    assert casper.functions.current_epoch().call() == next_epoch
 
 
-def test_double_epoch_initialization(casper_chain, casper, new_epoch, assert_tx_failed):
+def test_double_epoch_initialization(tester, casper, new_epoch, epoch_length, assert_tx_failed):
     new_epoch()
-    initial_epoch = casper.current_epoch()
+    initial_epoch = casper.functions.current_epoch().call()
 
-    casper_chain.mine(casper.EPOCH_LENGTH())
+    tester.mine_blocks(epoch_length - 2)
+    next_block_number = tester.get_block_by_number('latest')['number'] + 1
+    assert next_block_number % epoch_length == 0
 
     next_epoch = initial_epoch + 1
-    casper.initialize_epoch(next_epoch)
-    assert casper.current_epoch() == next_epoch
+    casper.functions.initialize_epoch(next_epoch).transact()
+    assert casper.functions.current_epoch().call() == next_epoch
     assert_tx_failed(
-        lambda: casper.initialize_epoch(next_epoch)
+        lambda: casper.functions.initialize_epoch(next_epoch).transact()
     )
 
 
-def test_epoch_initialization_one_block_late(casper_chain, casper, new_epoch):
-    epoch_length = casper.EPOCH_LENGTH()
-
+def test_epoch_initialization_one_block_late(tester, casper, epoch_length, new_epoch):
     new_epoch()
-    initial_epoch = casper.current_epoch()
+    initial_epoch = casper.functions.current_epoch().call()
 
-    casper_chain.mine(epoch_length + 1)
-    assert (casper_chain.head_state.block_number % epoch_length) == 1
+    tester.mine_blocks(epoch_length - 1)
+    next_block_number = tester.get_block_by_number('latest')['number'] + 1
+    assert (next_block_number % epoch_length) == 1
 
     expected_epoch = initial_epoch + 1
-    casper.initialize_epoch(expected_epoch)
+    casper.functions.initialize_epoch(expected_epoch).transact()
 
-    assert casper.current_epoch() == expected_epoch
+    assert casper.functions.current_epoch().call() == expected_epoch
 
 
-def test_epoch_initialize_one_epoch_late(casper_chain, casper, new_epoch, assert_tx_failed):
+def test_epoch_initialize_one_epoch_late(
+        tester,
+        casper,
+        new_epoch,
+        epoch_length,
+        assert_tx_failed):
     new_epoch()
-    initial_epoch = casper.current_epoch()
+    initial_epoch = casper.functions.current_epoch().call()
 
-    casper_chain.mine(casper.EPOCH_LENGTH() * 2)
+    tester.mine_blocks(epoch_length * 2 - 2)
+    next_block_number = tester.get_block_by_number('latest')['number'] + 1
+    assert (next_block_number % epoch_length) == 0
+
     assert_tx_failed(
-        lambda: casper.initialize_epoch(initial_epoch + 2)
+        lambda: casper.functions.initialize_epoch(initial_epoch + 2).transact()
     )
-    assert casper.current_epoch() == initial_epoch
-    casper.initialize_epoch(initial_epoch + 1)
-    assert casper.current_epoch() == initial_epoch + 1
-    casper.initialize_epoch(initial_epoch + 2)
-    assert casper.current_epoch() == initial_epoch + 2
+    assert casper.functions.current_epoch().call() == initial_epoch
+    casper.functions.initialize_epoch(initial_epoch + 1).transact()
+    assert casper.functions.current_epoch().call() == initial_epoch + 1
+    casper.functions.initialize_epoch(initial_epoch + 2).transact()
+    assert casper.functions.current_epoch().call() == initial_epoch + 2
 
 
-def test_checkpoint_hashes(casper_chain, casper, new_epoch):
+def test_checkpoint_hashes(tester, casper, epoch_length, new_epoch):
     for _ in range(4):
-        next_epoch = casper.current_epoch() + 1
-        epoch_length = casper.EPOCH_LENGTH()
+        next_epoch = casper.functions.current_epoch().call() + 1
 
-        casper_chain.mine(epoch_length * next_epoch - casper_chain.head_state.block_number)
+        block_number = tester.get_block_by_number('latest')['number']
+        tester.mine_blocks(epoch_length * next_epoch - block_number - 1)
 
-        casper.initialize_epoch(next_epoch)
-        current_epoch = casper.current_epoch()
-        # This looks incorrect but `get_block_hash` actually indexes
-        # into a list of prev_hashes. The 0th index is the hash of the previous block
-        expected_hash = casper_chain.head_state.get_block_hash(0)
+        next_block_number = tester.get_block_by_number('latest')['number'] + 1
+        assert (next_block_number % epoch_length) == 0
+
+        casper.functions.initialize_epoch(next_epoch).transact()
+        current_epoch = casper.functions.current_epoch().call()
+
+        checkpoint_block_number = next_block_number - 1
+        expected_hash = tester.get_block_by_number(checkpoint_block_number)['hash']
+        actual_hash = Web3.toHex(casper.functions.checkpoint_hashes(current_epoch).call())
 
         assert current_epoch == next_epoch
-        assert casper.checkpoint_hashes(current_epoch) == expected_hash
+        assert actual_hash == expected_hash
 
 
-def test_checkpoint_deposits(casper_chain, casper, funded_privkeys, deposit_amount,
-                             induct_validator, deposit_validator, new_epoch,
-                             mk_suggested_vote):
-    current_epoch = casper.current_epoch()
-    assert casper.checkpoints__cur_dyn_deposits(current_epoch) == 0
-    assert casper.checkpoints__prev_dyn_deposits(current_epoch) == 0
-
-    new_epoch()
-    current_epoch = casper.current_epoch()
-
-    assert casper.checkpoints__cur_dyn_deposits(current_epoch) == 0
-    assert casper.checkpoints__prev_dyn_deposits(current_epoch) == 0
-
-    initial_validator = deposit_validator(funded_privkeys[0], deposit_amount)
-
-    new_epoch()
-    current_epoch = casper.current_epoch()
-
-    assert casper.checkpoints__cur_dyn_deposits(current_epoch) == 0
-    assert casper.checkpoints__prev_dyn_deposits(current_epoch) == 0
+def test_checkpoint_deposits(
+        tester,
+        casper,
+        concise_casper,
+        funded_accounts,
+        validation_keys,
+        deposit_amount,
+        deposit_validator,
+        new_epoch,
+        mk_suggested_vote):
+    current_epoch = concise_casper.current_epoch()
+    assert concise_casper.checkpoints__cur_dyn_deposits(current_epoch) == 0
+    assert concise_casper.checkpoints__prev_dyn_deposits(current_epoch) == 0
 
     new_epoch()
-    current_epoch = casper.current_epoch()
+    current_epoch = concise_casper.current_epoch()
+
+    assert concise_casper.checkpoints__cur_dyn_deposits(current_epoch) == 0
+    assert concise_casper.checkpoints__prev_dyn_deposits(current_epoch) == 0
+
+    initial_validator = deposit_validator(funded_accounts[0], validation_keys[0], deposit_amount)
+
+    new_epoch()
+    current_epoch = concise_casper.current_epoch()
+
+    assert concise_casper.checkpoints__cur_dyn_deposits(current_epoch) == 0
+    assert concise_casper.checkpoints__prev_dyn_deposits(current_epoch) == 0
+
+    new_epoch()
+    current_epoch = concise_casper.current_epoch()
 
     # checkpoints are for the last block in the previous epoch
     # so checkpoint dynasty totals should lag behind
-    assert casper.total_curdyn_deposits_in_wei() == deposit_amount
-    assert casper.total_prevdyn_deposits_in_wei() == 0
-    assert casper.checkpoints__cur_dyn_deposits(current_epoch) == 0
-    assert casper.checkpoints__prev_dyn_deposits(current_epoch) == 0
+    assert concise_casper.total_curdyn_deposits_in_wei() == deposit_amount
+    assert concise_casper.total_prevdyn_deposits_in_wei() == 0
+    assert concise_casper.checkpoints__cur_dyn_deposits(current_epoch) == 0
+    assert concise_casper.checkpoints__prev_dyn_deposits(current_epoch) == 0
 
-    casper.vote(mk_suggested_vote(initial_validator, funded_privkeys[0]))
+    casper.functions.vote(
+        mk_suggested_vote(initial_validator, validation_keys[0])
+    ).transact()
     new_epoch()
-    current_epoch = casper.current_epoch()
+    current_epoch = concise_casper.current_epoch()
 
-    assert casper.total_curdyn_deposits_in_wei() == deposit_amount
-    assert casper.total_prevdyn_deposits_in_wei() == deposit_amount
-    assert casper.checkpoints__cur_dyn_deposits(current_epoch) == deposit_amount
-    assert casper.checkpoints__prev_dyn_deposits(current_epoch) == 0
+    assert concise_casper.total_curdyn_deposits_in_wei() == deposit_amount
+    assert concise_casper.total_prevdyn_deposits_in_wei() == deposit_amount
+    assert concise_casper.checkpoints__cur_dyn_deposits(current_epoch) == deposit_amount
+    assert concise_casper.checkpoints__prev_dyn_deposits(current_epoch) == 0
 
-    second_validator = deposit_validator(funded_privkeys[1], deposit_amount)
+    second_validator = deposit_validator(funded_accounts[1], validation_keys[1], deposit_amount)
 
-    casper.vote(mk_suggested_vote(initial_validator, funded_privkeys[0]))
+    casper.functions.vote(
+        mk_suggested_vote(initial_validator, validation_keys[0])
+    ).transact()
     new_epoch()
-    current_epoch = casper.current_epoch()
+    current_epoch = concise_casper.current_epoch()
 
-    assert casper.total_curdyn_deposits_in_wei() == deposit_amount
-    assert casper.total_prevdyn_deposits_in_wei() == deposit_amount
-    assert casper.checkpoints__cur_dyn_deposits(current_epoch) == deposit_amount
-    assert casper.checkpoints__prev_dyn_deposits(current_epoch) == deposit_amount
+    assert concise_casper.total_curdyn_deposits_in_wei() == deposit_amount
+    assert concise_casper.total_prevdyn_deposits_in_wei() == deposit_amount
+    assert concise_casper.checkpoints__cur_dyn_deposits(current_epoch) == deposit_amount
+    assert concise_casper.checkpoints__prev_dyn_deposits(current_epoch) == deposit_amount
 
-    prev_curdyn_deposits = casper.total_curdyn_deposits_in_wei()
-    prev_prevdyn_deposits = casper.total_prevdyn_deposits_in_wei()
+    prev_curdyn_deposits = concise_casper.total_curdyn_deposits_in_wei()
+    prev_prevdyn_deposits = concise_casper.total_prevdyn_deposits_in_wei()
 
-    casper.vote(mk_suggested_vote(initial_validator, funded_privkeys[0]))
+    casper.functions.vote(
+        mk_suggested_vote(initial_validator, validation_keys[0])
+    ).transact()
     new_epoch()
-    current_epoch = casper.current_epoch()
+    current_epoch = concise_casper.current_epoch()
 
-    assert casper.checkpoints__cur_dyn_deposits(current_epoch) >= prev_curdyn_deposits \
-        and casper.checkpoints__cur_dyn_deposits(current_epoch) < prev_curdyn_deposits * 1.01
-    assert casper.checkpoints__prev_dyn_deposits(current_epoch) >= prev_prevdyn_deposits \
-        and casper.checkpoints__prev_dyn_deposits(current_epoch) < prev_prevdyn_deposits * 1.01
+    cur_dyn_deposits = concise_casper.checkpoints__cur_dyn_deposits(current_epoch)
+    prev_dyn_deposits = concise_casper.checkpoints__prev_dyn_deposits(current_epoch)
+    assert cur_dyn_deposits >= prev_curdyn_deposits \
+        and cur_dyn_deposits < prev_curdyn_deposits * 1.01
+    assert prev_dyn_deposits >= prev_prevdyn_deposits \
+        and prev_dyn_deposits < prev_prevdyn_deposits * 1.01
 
     for _ in range(3):
-        prev_curdyn_deposits = casper.total_curdyn_deposits_in_wei()
-        prev_prevdyn_deposits = casper.total_prevdyn_deposits_in_wei()
+        prev_curdyn_deposits = concise_casper.total_curdyn_deposits_in_wei()
+        prev_prevdyn_deposits = concise_casper.total_prevdyn_deposits_in_wei()
 
-        casper.vote(mk_suggested_vote(initial_validator, funded_privkeys[0]))
-        casper.vote(mk_suggested_vote(second_validator, funded_privkeys[1]))
+        casper.functions.vote(
+            mk_suggested_vote(initial_validator, validation_keys[0])
+        ).transact()
+        casper.functions.vote(
+            mk_suggested_vote(second_validator, validation_keys[1])
+        ).transact()
         new_epoch()
-        current_epoch = casper.current_epoch()
+        current_epoch = concise_casper.current_epoch()
 
-        assert casper.checkpoints__cur_dyn_deposits(current_epoch) >= prev_curdyn_deposits \
-            and casper.checkpoints__cur_dyn_deposits(current_epoch) < prev_curdyn_deposits * 1.01
-        assert casper.checkpoints__prev_dyn_deposits(current_epoch) >= prev_prevdyn_deposits \
-            and casper.checkpoints__prev_dyn_deposits(current_epoch) < prev_prevdyn_deposits * 1.01
+        cur_dyn_deposits = concise_casper.checkpoints__cur_dyn_deposits(current_epoch)
+        prev_dyn_deposits = concise_casper.checkpoints__prev_dyn_deposits(current_epoch)
+
+        assert cur_dyn_deposits >= prev_curdyn_deposits \
+            and cur_dyn_deposits < prev_curdyn_deposits * 1.01
+        assert prev_dyn_deposits >= prev_prevdyn_deposits \
+            and prev_dyn_deposits < prev_prevdyn_deposits * 1.01

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -3,170 +3,209 @@ from utils.common_assertions import (
 )
 
 
-def test_logout_sets_end_dynasty(casper, funded_privkey, deposit_amount,
+def test_logout_sets_end_dynasty(concise_casper,
+                                 funded_account,
+                                 validation_key,
+                                 deposit_amount,
                                  induct_validator,
                                  logout_validator_via_signed_msg):
-    validator_index = induct_validator(funded_privkey, deposit_amount)
+    validator_index = induct_validator(funded_account, validation_key, deposit_amount)
 
-    expected_end_dynasty = casper.dynasty() + casper.DYNASTY_LOGOUT_DELAY()
-    assert casper.validators__end_dynasty(validator_index) == 1000000000000000000000000000000
+    expected_end_dynasty = concise_casper.dynasty() + concise_casper.DYNASTY_LOGOUT_DELAY()
+    end_dynasty = concise_casper.validators__end_dynasty(validator_index)
+    assert end_dynasty == 1000000000000000000000000000000
 
-    logout_validator_via_signed_msg(validator_index, funded_privkey)
+    logout_validator_via_signed_msg(validator_index, validation_key)
 
-    assert casper.validators__end_dynasty(validator_index) == expected_end_dynasty
+    end_dynasty = concise_casper.validators__end_dynasty(validator_index)
+    assert end_dynasty == expected_end_dynasty
 
 
-def test_logout_sets_total_deposits_at_logout(casper, funded_privkey, deposit_amount,
+def test_logout_sets_total_deposits_at_logout(concise_casper,
+                                              funded_account,
+                                              validation_key,
+                                              deposit_amount,
                                               induct_validator,
                                               logout_validator_via_signed_msg):
-    validator_index = induct_validator(funded_privkey, deposit_amount)
-    assert casper.validators__total_deposits_at_logout(validator_index) == 0
+    validator_index = induct_validator(funded_account, validation_key, deposit_amount)
+    assert concise_casper.validators__total_deposits_at_logout(validator_index) == 0
 
-    logout_validator_via_signed_msg(validator_index, funded_privkey)
+    logout_validator_via_signed_msg(validator_index, validation_key)
 
-    assert casper.validators__total_deposits_at_logout(validator_index) == deposit_amount
+    deposits_at_logout = concise_casper.validators__total_deposits_at_logout(validator_index)
+    assert deposits_at_logout == deposit_amount
 
 
-def test_logout_updates_dynasty_wei_delta(casper, funded_privkey, deposit_amount,
+def test_logout_updates_dynasty_wei_delta(concise_casper,
+                                          funded_account,
+                                          validation_key,
+                                          deposit_amount,
                                           induct_validator,
                                           logout_validator_via_signed_msg):
-    validator_index = induct_validator(funded_privkey, deposit_amount)
-    scaled_deposit_size = casper.validators__deposit(validator_index)
+    validator_index = induct_validator(funded_account, validation_key, deposit_amount)
+    scaled_deposit_size = concise_casper.validators__deposit(validator_index)
 
-    expected_end_dynasty = casper.dynasty() + casper.DYNASTY_LOGOUT_DELAY()
-    assert casper.dynasty_wei_delta(expected_end_dynasty) == 0
+    expected_end_dynasty = concise_casper.dynasty() + concise_casper.DYNASTY_LOGOUT_DELAY()
+    assert concise_casper.dynasty_wei_delta(expected_end_dynasty) == 0
 
-    logout_validator_via_signed_msg(validator_index, funded_privkey)
+    logout_validator_via_signed_msg(validator_index, validation_key)
 
-    assert casper.dynasty_wei_delta(expected_end_dynasty) == -scaled_deposit_size
-
-
-def test_logout_with_multiple_validators(casper, funded_privkeys,
-                                         deposit_amount, new_epoch, induct_validators,
-                                         mk_suggested_vote,
-                                         logout_validator_via_signed_msg):
-    validator_indexes = induct_validators(funded_privkeys, [deposit_amount] * len(funded_privkeys))
-    num_validators = len(validator_indexes)
-    assert casper.total_curdyn_deposits_in_wei() == deposit_amount * len(funded_privkeys)
-
-    # finalize 3 epochs to get to a stable state
-    for _ in range(3):
-        for i, validator_index in enumerate(validator_indexes):
-            casper.vote(mk_suggested_vote(validator_index, funded_privkeys[i]))
-        new_epoch()
-
-    # 0th logs out
-    logged_out_index = validator_indexes[0]
-    logged_out_privkey = funded_privkeys[0]
-    # the rest remain
-    logged_in_indexes = validator_indexes[1:]
-    logged_in_privkeys = funded_privkeys[1:]
-
-    logout_validator_via_signed_msg(logged_out_index, logged_out_privkey)
-
-    # enter validator's end_dynasty (validator in prevdyn)
-    dynasty_logout_delay = casper.DYNASTY_LOGOUT_DELAY()
-    for _ in range(dynasty_logout_delay):
-        for i, validator_index in enumerate(validator_indexes):
-            casper.vote(mk_suggested_vote(validator_index, funded_privkeys[i]))
-        new_epoch()
-    assert casper.validators__end_dynasty(logged_out_index) == casper.dynasty()
-
-    logged_in_deposit_size = sum(map(casper.deposit_size, logged_in_indexes))
-    logging_out_deposit_size = casper.deposit_size(logged_out_index)
-    total_deposit_size = logged_in_deposit_size + logging_out_deposit_size
-
-    assert abs(logged_in_deposit_size - casper.total_curdyn_deposits_in_wei()) < num_validators
-    assert abs(total_deposit_size - casper.total_prevdyn_deposits_in_wei()) < num_validators
-
-    # validator no longer in prev or cur dyn
-    for i, validator_index in enumerate(logged_in_indexes):
-        casper.vote(mk_suggested_vote(validator_index, logged_in_privkeys[i]))
-    new_epoch()
-
-    logged_in_deposit_size = sum(map(casper.deposit_size, logged_in_indexes))
-
-    assert abs(logged_in_deposit_size - casper.total_curdyn_deposits_in_wei()) < num_validators
-    assert abs(logged_in_deposit_size - casper.total_prevdyn_deposits_in_wei()) < num_validators
-
-    # validator can withdraw after delay
-    for i in range(casper.WITHDRAWAL_DELAY()):
-        for i, validator_index in enumerate(logged_in_indexes):
-            casper.vote(mk_suggested_vote(validator_index, logged_in_privkeys[i]))
-        new_epoch()
-
-    withdrawal_amount = casper.deposit_size(logged_out_index)
-    assert withdrawal_amount > 0
-
-    casper.withdraw(logged_out_index)
-    assert_validator_empty(casper, logged_out_index)
+    assert concise_casper.dynasty_wei_delta(expected_end_dynasty) == -scaled_deposit_size
 
 
-def test_logout_from_withdrawal_address_without_signature(casper,
-                                                          funded_privkey,
+def test_logout_from_withdrawal_address_without_signature(concise_casper,
+                                                          funded_account,
+                                                          validation_key,
                                                           deposit_amount,
                                                           induct_validator,
                                                           logout_validator_via_unsigned_msg):
-    validator_index = induct_validator(funded_privkey, deposit_amount)
-    expected_end_dynasty = casper.dynasty() + casper.DYNASTY_LOGOUT_DELAY()
+    validator_index = induct_validator(funded_account, validation_key, deposit_amount)
+    expected_end_dynasty = concise_casper.dynasty() + concise_casper.DYNASTY_LOGOUT_DELAY()
 
-    logout_validator_via_unsigned_msg(validator_index, funded_privkey)
+    logout_validator_via_unsigned_msg(validator_index, funded_account)
 
-    assert casper.validators__end_dynasty(validator_index) == expected_end_dynasty
+    assert concise_casper.validators__end_dynasty(validator_index) == expected_end_dynasty
 
 
-def test_logout_from_withdrawal_address_with_signature(casper,
-                                                       funded_privkey,
+def test_logout_from_withdrawal_address_with_signature(concise_casper,
+                                                       funded_account,
+                                                       validation_key,
                                                        deposit_amount,
                                                        induct_validator,
                                                        logout_validator_via_signed_msg,
                                                        assert_tx_failed):
-    validator_index = induct_validator(funded_privkey, deposit_amount)
-    expected_end_dynasty = casper.dynasty() + casper.DYNASTY_LOGOUT_DELAY()
+    validator_index = induct_validator(funded_account, validation_key, deposit_amount)
+    expected_end_dynasty = concise_casper.dynasty() + concise_casper.DYNASTY_LOGOUT_DELAY()
 
     logout_validator_via_signed_msg(
         validator_index,
-        funded_privkey,
-        funded_privkey
+        validation_key,
+        funded_account
     )
 
-    assert casper.validators__end_dynasty(validator_index) == expected_end_dynasty
+    assert concise_casper.validators__end_dynasty(validator_index) == expected_end_dynasty
 
 
 def test_logout_from_non_withdrawal_address_without_signature(casper,
-                                                              funded_privkeys,
+                                                              funded_accounts,
+                                                              validation_keys,
                                                               deposit_amount,
                                                               induct_validator,
                                                               logout_validator_via_unsigned_msg,
                                                               assert_tx_failed):
-    validator_key = funded_privkeys[0]
-    non_validator_key = funded_privkeys[1]
-    assert validator_key != non_validator_key
+    validator_key = validation_keys[0]
+    validator_addr = funded_accounts[0]
+    non_validator_addr = funded_accounts[1]
+    assert validator_addr != non_validator_addr
 
-    validator_index = induct_validator(validator_key, deposit_amount)
+    validator_index = induct_validator(validator_addr, validator_key, deposit_amount)
 
     assert_tx_failed(
-        lambda: logout_validator_via_unsigned_msg(validator_index, non_validator_key)
+        lambda: logout_validator_via_unsigned_msg(validator_index, non_validator_addr)
     )
 
 
-def test_logout_from_non_withdrawal_address_with_signature(casper,
-                                                           funded_privkeys,
+def test_logout_from_non_withdrawal_address_with_signature(concise_casper,
+                                                           funded_accounts,
+                                                           validation_keys,
                                                            deposit_amount,
                                                            induct_validator,
                                                            logout_validator_via_signed_msg,
                                                            assert_tx_failed):
-    validator_key = funded_privkeys[0]
-    non_validator_key = funded_privkeys[1]
-    assert validator_key != non_validator_key
+    validator_key = validation_keys[0]
+    validator_addr = funded_accounts[0]
+    non_validator_addr = funded_accounts[1]
+    assert validator_addr != non_validator_addr
 
-    validator_index = induct_validator(validator_key, deposit_amount)
-    expected_end_dynasty = casper.dynasty() + casper.DYNASTY_LOGOUT_DELAY()
+    validator_index = induct_validator(validator_addr, validator_key, deposit_amount)
+    expected_end_dynasty = concise_casper.dynasty() + concise_casper.DYNASTY_LOGOUT_DELAY()
 
     logout_validator_via_signed_msg(
         validator_index,
         validator_key,
-        non_validator_key
+        non_validator_addr
     )
 
-    assert casper.validators__end_dynasty(validator_index) == expected_end_dynasty
+    assert concise_casper.validators__end_dynasty(validator_index) == expected_end_dynasty
+
+
+def test_logout_with_multiple_validators(casper,
+                                         concise_casper,
+                                         funded_accounts,
+                                         validation_keys,
+                                         deposit_amount,
+                                         new_epoch,
+                                         induct_validators,
+                                         mk_suggested_vote,
+                                         logout_validator_via_signed_msg):
+    validator_indexes = induct_validators(
+        funded_accounts,
+        validation_keys,
+        [deposit_amount] * len(funded_accounts)
+    )
+    num_validators = len(validator_indexes)
+    assert concise_casper.total_curdyn_deposits_in_wei() == deposit_amount * len(funded_accounts)
+
+    # finalize 3 epochs to get to a stable state
+    for _ in range(3):
+        for key, validator_index in zip(validation_keys, validator_indexes):
+            casper.functions.vote(
+               mk_suggested_vote(validator_index, key)
+            ).transact()
+        new_epoch()
+
+    # 0th logs out
+    logged_out_index = validator_indexes[0]
+    logged_out_key = validation_keys[0]
+    # the rest remain
+    logged_in_indexes = validator_indexes[1:]
+    logged_in_keys = validation_keys[1:]
+
+    logout_validator_via_signed_msg(logged_out_index, logged_out_key)
+
+    # enter validator's end_dynasty (validator in prevdyn)
+    dynasty_logout_delay = concise_casper.DYNASTY_LOGOUT_DELAY()
+    for _ in range(dynasty_logout_delay):
+        for key, validator_index in zip(validation_keys, validator_indexes):
+            casper.functions.vote(
+                mk_suggested_vote(validator_index, key)
+            ).transact()
+        new_epoch()
+    assert concise_casper.validators__end_dynasty(logged_out_index) == concise_casper.dynasty()
+
+    logged_in_deposit_size = sum(map(concise_casper.deposit_size, logged_in_indexes))
+    logging_out_deposit_size = concise_casper.deposit_size(logged_out_index)
+    total_deposit_size = logged_in_deposit_size + logging_out_deposit_size
+
+    curdyn_deposits = concise_casper.total_curdyn_deposits_in_wei()
+    prevdyn_deposits = concise_casper.total_prevdyn_deposits_in_wei()
+    assert abs(logged_in_deposit_size - curdyn_deposits) < num_validators
+    assert abs(total_deposit_size - prevdyn_deposits) < num_validators
+
+    # validator no longer in prev or cur dyn
+    for key, validator_index in zip(logged_in_keys, logged_in_indexes):
+        casper.functions.vote(
+            mk_suggested_vote(validator_index, key)
+        ).transact()
+    new_epoch()
+
+    logged_in_deposit_size = sum(map(concise_casper.deposit_size, logged_in_indexes))
+
+    curdyn_deposits = concise_casper.total_curdyn_deposits_in_wei()
+    prevdyn_deposits = concise_casper.total_prevdyn_deposits_in_wei()
+    assert abs(logged_in_deposit_size - curdyn_deposits) < num_validators
+    assert abs(logged_in_deposit_size - prevdyn_deposits) < num_validators
+
+    # validator can withdraw after delay
+    for _ in range(concise_casper.WITHDRAWAL_DELAY()):
+        for key, validator_index in zip(logged_in_keys, logged_in_indexes):
+            casper.functions.vote(
+                mk_suggested_vote(validator_index, key)
+            ).transact()
+        new_epoch()
+
+    withdrawal_amount = concise_casper.deposit_size(logged_out_index)
+    assert withdrawal_amount > 0
+
+    casper.functions.withdraw(logged_out_index).transact()
+    assert_validator_empty(concise_casper, logged_out_index)

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,90 +1,93 @@
 import math
-from ethereum import utils
+
+from web3 import Web3
 
 
-def test_epoch_insta_finalize_logs(casper, new_epoch, get_logs, casper_chain):
-    start_epoch = casper.START_EPOCH()
+def test_epoch_insta_finalize_logs(tester,
+                                   concise_casper,
+                                   casper_epoch_filter,
+                                   new_epoch):
+    start_epoch = concise_casper.START_EPOCH()
     new_epoch()
     new_epoch()
-    # Test epoch logs
-    receipt = casper_chain.head_state.receipts[-1]
-    logs = get_logs(receipt, casper)
-    assert len(logs) == 2
-    log_old = logs[-2]
-    log_new = logs[-1]
+    logs = casper_epoch_filter.get_new_entries()
+    assert len(logs) == 4
+    log_old = logs[-2]['args']
+    log_new = logs[-1]['args']
 
     log_fields = {
-        '_event_type', '_number', '_checkpoint_hash',
-        '_is_justified', '_is_finalized'
+        '_number',
+        '_checkpoint_hash',
+        '_is_justified',
+        '_is_finalized'
     }
     assert log_fields == log_old.keys()
 
     # New epoch log
-    assert log_new['_event_type'] == b'Epoch'
     assert log_new['_number'] == start_epoch + 2
-    last_block_number = casper_chain.block.number
+    init_block_number = tester.get_block_by_number('latest')['number'] - 1
     # block before epoch init == checkpoint hash
-    assert log_new['_checkpoint_hash'] == \
-        casper_chain.chain.get_blockhash_by_number(last_block_number - 1)
+    assert Web3.toHex(log_new['_checkpoint_hash']) == \
+        tester.get_block_by_number(init_block_number - 1)['hash']
     assert log_new['_is_justified'] is False
     assert log_new['_is_finalized'] is False
 
     # Insta-finalized previous epoch
-    assert log_old['_event_type'] == b'Epoch'
     assert log_old['_number'] == start_epoch + 1
     # block before previous epoch init == checkpoint hash
-    prev_epoch_block_number = last_block_number - casper.EPOCH_LENGTH() - 1
-    assert log_old['_checkpoint_hash'] == \
-        casper_chain.chain.get_blockhash_by_number(prev_epoch_block_number)
+    prev_epoch_block_number = init_block_number - concise_casper.EPOCH_LENGTH()
+    assert Web3.toHex(log_old['_checkpoint_hash']) == \
+        tester.get_block_by_number(prev_epoch_block_number - 1)['hash']
     assert log_old['_is_justified'] is True
     assert log_old['_is_finalized'] is True
 
 
-def test_epoch_with_validator_logs(casper, new_epoch, get_logs, casper_chain,
-                                   deposit_validator, funded_privkey,
-                                   deposit_amount, mk_suggested_vote):
-    validator_index = casper.next_validator_index()
-    deposit_validator(funded_privkey, deposit_amount)
-    # Validator is registered in Casper
-    assert validator_index == casper.validator_indexes(utils.privtoaddr(funded_privkey))
+def test_epoch_with_validator_logs(tester,
+                                   casper,
+                                   concise_casper,
+                                   casper_epoch_filter,
+                                   new_epoch,
+                                   induct_validator,
+                                   funded_account,
+                                   validation_key,
+                                   deposit_amount,
+                                   mk_suggested_vote):
+    validator_index = induct_validator(funded_account, validation_key, deposit_amount)
 
-    for _ in range(3):
-        new_epoch()
-    last_block_number = casper_chain.block.number
-    # Allowed to vote now
-    assert casper.validators__start_dynasty(validator_index) == casper.dynasty()
+    last_block_number = tester.get_block_by_number('latest')['number'] - 1
 
-    casper.vote(mk_suggested_vote(validator_index, funded_privkey))
-    receipt = casper_chain.head_state.receipts[-1]
-    logs = get_logs(receipt, casper)
-    assert len(logs) == 3  # Vote + Last Epoch + Prev Epoch
-    last_epoch_hash = casper_chain.chain.get_blockhash_by_number(last_block_number - 1)
+    casper.functions.vote(
+        mk_suggested_vote(validator_index, validation_key)
+    ).transact()
+
+    logs = casper_epoch_filter.get_new_entries()
+    last_epoch_hash = tester.get_block_by_number(last_block_number - 1)['hash']
     last_epoch_log = [
         log for log in logs
-        if log['_event_type'] == b'Epoch' and log['_checkpoint_hash'] == last_epoch_hash
-    ][0]
+        if Web3.toHex(log['args']['_checkpoint_hash']) == last_epoch_hash
+    ][-1]['args']
     assert last_epoch_log['_is_justified'] is True
     assert last_epoch_log['_is_finalized'] is False
 
     new_epoch()
-    last_block_number = casper_chain.block.number
-    casper.vote(mk_suggested_vote(validator_index, funded_privkey))
+    last_block_number = tester.get_block_by_number('latest')['number'] - 1
+    casper.functions.vote(
+        mk_suggested_vote(validator_index, validation_key)
+    ).transact()
 
-    receipt = casper_chain.head_state.receipts[-1]
-    logs = get_logs(receipt, casper)
-    assert len(logs) == 3  # Vote + Last Epoch + Prev Epoch
-    last_epoch_hash = casper_chain.chain.get_blockhash_by_number(last_block_number - 1)
+    logs = casper_epoch_filter.get_new_entries()
+    last_epoch_hash = tester.get_block_by_number(last_block_number - 1)['hash']
     last_epoch_log = [
         log for log in logs
-        if log['_event_type'] == b'Epoch' and log['_checkpoint_hash'] == last_epoch_hash
-    ][0]
-    prev_epoch_hash = casper_chain.chain.get_blockhash_by_number(
-        last_block_number - casper.EPOCH_LENGTH() - 1
-    )
+        if Web3.toHex(log['args']['_checkpoint_hash']) == last_epoch_hash
+    ][-1]['args']
+    prev_epoch_hash = tester.get_block_by_number(
+        last_block_number - concise_casper.EPOCH_LENGTH() - 1
+    )['hash']
     prev_epoch_log = [
         log for log in logs
-        if log['_event_type'] == b'Epoch' and log['_checkpoint_hash'] == prev_epoch_hash
-    ][0]
+        if Web3.toHex(log['args']['_checkpoint_hash']) == prev_epoch_hash
+    ][-1]['args']
 
     assert prev_epoch_log['_is_justified'] is True
     assert prev_epoch_log['_is_finalized'] is True
@@ -93,172 +96,203 @@ def test_epoch_with_validator_logs(casper, new_epoch, get_logs, casper_chain,
     assert last_epoch_log['_is_finalized'] is False
 
 
-def test_deposit_log(casper, funded_privkey, new_epoch, deposit_validator,
-                     deposit_amount, get_last_log, casper_chain):
-    start_epoch = casper.START_EPOCH()
+def test_deposit_log(concise_casper,
+                     casper_deposit_filter,
+                     funded_account,
+                     validation_key,
+                     new_epoch,
+                     deposit_validator,
+                     deposit_amount):
+    start_epoch = concise_casper.START_EPOCH()
     new_epoch()
-    assert casper.current_epoch() == start_epoch + 1
-    assert casper.next_validator_index() == 1
+    assert concise_casper.current_epoch() == start_epoch + 1
 
-    validator_index = casper.next_validator_index()
-    deposit_validator(funded_privkey, deposit_amount)
-    # Validator is registered in Casper
-    assert validator_index == casper.validator_indexes(utils.privtoaddr(funded_privkey))
+    validator_index = deposit_validator(funded_account, validation_key, deposit_amount)
+
+    logs = casper_deposit_filter.get_new_entries()
+    assert len(logs) == 1
+    log = logs[-1]['args']
 
     # Deposit log
-    log = get_last_log(casper_chain, casper)
     log_fields = {
-        '_event_type', '_from', '_validation_address',
-        '_validator_index', '_start_dyn', '_amount'
+        '_from',
+        '_validation_address',
+        '_validator_index',
+        '_start_dyn',
+        '_amount'
     }
     assert log_fields == log.keys()
-    assert log['_event_type'] == b'Deposit'
-    assert log['_from'] == '0x' + utils.encode_hex(utils.privtoaddr(funded_privkey))
-    assert log['_validation_address'] == casper.validators__addr(validator_index)
+    assert log['_from'] == funded_account
+    assert log['_validation_address'] == concise_casper.validators__addr(validator_index)
     assert log['_validator_index'] == validator_index
-    assert log['_start_dyn'] == casper.validators__start_dynasty(validator_index)
+    assert log['_start_dyn'] == concise_casper.validators__start_dynasty(validator_index)
     assert log['_amount'] == deposit_amount
 
 
-def test_vote_log(casper, funded_privkey, new_epoch, deposit_validator,
-                  deposit_amount, get_last_log, casper_chain, mk_suggested_vote):
-    new_epoch()
-    validator_index = casper.next_validator_index()
-    deposit_validator(funded_privkey, deposit_amount)
-    # Validator is registered in Casper
-    assert validator_index == casper.validator_indexes(utils.privtoaddr(funded_privkey))
+def test_vote_log(casper,
+                  concise_casper,
+                  casper_vote_filter,
+                  funded_account,
+                  validation_key,
+                  new_epoch,
+                  induct_validator,
+                  deposit_amount,
+                  mk_suggested_vote):
+    validator_index = induct_validator(funded_account, validation_key, deposit_amount)
 
-    new_epoch()
-    new_epoch()
-    # Allowed to vote now
-    assert casper.validators__start_dynasty(validator_index) == casper.dynasty()
+    casper.functions.vote(
+        mk_suggested_vote(validator_index, validation_key)
+    ).transact()
 
-    casper.vote(mk_suggested_vote(validator_index, funded_privkey))
-    # Vote log
-    log = get_last_log(casper_chain, casper)
+    logs = casper_vote_filter.get_new_entries()
+    assert len(logs) == 1
+    log = logs[-1]['args']
+
     log_fields = {
-        '_event_type', '_from', '_validator_index',
+        '_from', '_validator_index',
         '_target_hash', '_target_epoch', '_source_epoch'
     }
     assert log_fields == log.keys()
-    assert log['_event_type'] == b'Vote'
-    assert log['_from'] == '0x' + utils.encode_hex(utils.privtoaddr(funded_privkey))
+    assert log['_from'] == funded_account
     assert log['_validator_index'] == validator_index
-    assert log['_target_hash'] == casper.recommended_target_hash()
-    assert log['_target_epoch'] == casper.recommended_source_epoch() + 1
-    assert log['_source_epoch'] == casper.recommended_source_epoch()
+    assert log['_target_hash'] == concise_casper.recommended_target_hash()
+    assert log['_target_epoch'] == concise_casper.recommended_source_epoch() + 1
+    assert log['_source_epoch'] == concise_casper.recommended_source_epoch()
 
 
-def test_logout_log(casper, funded_privkey, new_epoch, deposit_validator,
-                    logout_validator_via_signed_msg,
-                    deposit_amount, get_last_log, casper_chain, mk_suggested_vote):
-    new_epoch()
-    validator_index = casper.next_validator_index()
-    deposit_validator(funded_privkey, deposit_amount)
-    # Validator is registered in Casper
-    assert validator_index == casper.validator_indexes(utils.privtoaddr(funded_privkey))
+def test_logout_log(casper,
+                    concise_casper,
+                    casper_logout_filter,
+                    funded_account,
+                    validation_key,
+                    new_epoch,
+                    induct_validator,
+                    deposit_amount,
+                    mk_suggested_vote,
+                    logout_validator_via_signed_msg):
+    validator_index = induct_validator(funded_account, validation_key, deposit_amount)
 
-    new_epoch()
-    new_epoch()
-    # Allowed to vote now
-    assert casper.validators__start_dynasty(validator_index) == casper.dynasty()
+    casper.functions.vote(
+        mk_suggested_vote(validator_index, validation_key)
+    ).transact()
 
-    casper.vote(mk_suggested_vote(validator_index, funded_privkey))
+    logout_validator_via_signed_msg(validator_index, validation_key)
 
-    logout_validator_via_signed_msg(validator_index, funded_privkey)
-    # Logout log
-    log = get_last_log(casper_chain, casper)
-    assert {'_event_type', '_from', '_validator_index', '_end_dyn'} == log.keys()
-    assert log['_event_type'] == b'Logout'
-    assert log['_from'] == '0x' + utils.encode_hex(utils.privtoaddr(funded_privkey))
+    logs = casper_logout_filter.get_new_entries()
+    assert len(logs) == 1
+    log = logs[-1]['args']
+
+    log_fields = {
+        '_from',
+        '_validator_index',
+        '_end_dyn'
+    }
+    assert log_fields == log.keys()
+    assert log['_from'] == funded_account
     assert log['_validator_index'] == validator_index
-    assert log['_end_dyn'] == casper.dynasty() + casper.DYNASTY_LOGOUT_DELAY()
+    assert log['_end_dyn'] == concise_casper.dynasty() + concise_casper.DYNASTY_LOGOUT_DELAY()
 
 
-def test_withdraw_log(casper, funded_privkey, new_epoch, deposit_validator,
-                      logout_validator_via_signed_msg,
-                      deposit_amount, get_last_log, casper_chain,
-                      mk_suggested_vote):
+def test_withdraw_log(w3,
+                      casper,
+                      concise_casper,
+                      casper_withdraw_filter,
+                      funded_account,
+                      validation_key,
+                      new_epoch,
+                      induct_validator,
+                      deposit_amount,
+                      mk_suggested_vote,
+                      logout_validator_via_signed_msg):
+    validator_index = induct_validator(funded_account, validation_key, deposit_amount)
+
+    casper.functions.vote(
+        mk_suggested_vote(validator_index, validation_key)
+    ).transact()
     new_epoch()
-    validator_index = casper.next_validator_index()
-    deposit_validator(funded_privkey, deposit_amount)
-    # Validator is registered in Casper
-    assert validator_index == casper.validator_indexes(utils.privtoaddr(funded_privkey))
 
-    new_epoch()
-    new_epoch()
-    # Allowed to vote now
-    assert casper.validators__start_dynasty(validator_index) == casper.dynasty()
-
-    casper.vote(mk_suggested_vote(validator_index, funded_privkey))
-    new_epoch()
-
-    logout_validator_via_signed_msg(validator_index, funded_privkey)
+    logout_validator_via_signed_msg(validator_index, validation_key)
     # Logout delay
-    for _ in range(casper.DYNASTY_LOGOUT_DELAY() + 1):
-        casper.vote(mk_suggested_vote(validator_index, funded_privkey))
+    for _ in range(concise_casper.DYNASTY_LOGOUT_DELAY() + 1):
+        casper.functions.vote(
+            mk_suggested_vote(validator_index, validation_key)
+        ).transact()
         new_epoch()
+
     # In the next dynasty after end_dynasty
-    assert casper.validators__end_dynasty(validator_index) + 1 == casper.dynasty()
+    assert concise_casper.validators__end_dynasty(validator_index) + 1 == concise_casper.dynasty()
 
     # Withdrawal delay
-    for _ in range(casper.WITHDRAWAL_DELAY()):
+    for _ in range(concise_casper.WITHDRAWAL_DELAY()):
         new_epoch()
 
-    cur_epoch = casper.current_epoch()
-    end_epoch = casper.dynasty_start_epoch(
-        casper.validators__end_dynasty(validator_index) + 1
-    )
-    # Allowed to withdraw
-    assert cur_epoch == end_epoch + casper.WITHDRAWAL_DELAY()
+    current_epoch = concise_casper.current_epoch()
+    end_dynasty = concise_casper.validators__end_dynasty(validator_index)
+    end_epoch = concise_casper.dynasty_start_epoch(end_dynasty + 1)
 
-    expected_amount = casper.deposit_size(validator_index)
-    casper.withdraw(validator_index)
+    # Allowed to withdraw
+    assert current_epoch == end_epoch + concise_casper.WITHDRAWAL_DELAY()
+
+    expected_amount = concise_casper.deposit_size(validator_index)
+
+    prev_balance = w3.eth.getBalance(funded_account)
+    casper.functions.withdraw(validator_index).transact()
+    balance = w3.eth.getBalance(funded_account)
+    assert balance > prev_balance
 
     # Withdrawal log
-    log = get_last_log(casper_chain, casper)
-    assert {'_event_type', '_to', '_validator_index', '_amount'} == log.keys()
-    assert log['_event_type'] == b'Withdraw'
-    assert log['_to'] == '0x' + utils.encode_hex(utils.privtoaddr(funded_privkey))
+    logs = casper_withdraw_filter.get_new_entries()
+    assert len(logs) == 1
+    log = logs[-1]['args']
+
+    log_fields = {
+        '_to',
+        '_validator_index',
+        '_amount'
+    }
+    assert log_fields == log.keys()
+    assert log['_to'] == funded_account
     assert log['_validator_index'] == validator_index
     assert log['_amount'] == expected_amount
 
 
-def test_slash_log(casper, funded_privkey, deposit_amount, get_last_log, base_sender_privkey,
-                   induct_validator, mk_vote, fake_hash, casper_chain):
-    validator_index = induct_validator(funded_privkey, deposit_amount)
-    assert casper.total_curdyn_deposits_in_wei() == deposit_amount
+def test_slash_log(casper,
+                   concise_casper,
+                   casper_slash_filter,
+                   funded_account,
+                   validation_key,
+                   new_epoch,
+                   induct_validator,
+                   deposit_amount,
+                   mk_slash_votes,
+                   base_sender,
+                   logout_validator_via_signed_msg):
+    validator_index = induct_validator(funded_account, validation_key, deposit_amount)
 
-    vote_1 = mk_vote(
-        validator_index,
-        casper.recommended_target_hash(),
-        casper.current_epoch(),
-        casper.recommended_source_epoch(),
-        funded_privkey
-    )
-    vote_2 = mk_vote(
-        validator_index,
-        fake_hash,
-        casper.current_epoch(),
-        casper.recommended_source_epoch(),
-        funded_privkey
-    )
+    vote_1, vote_2 = mk_slash_votes(validator_index, validation_key)
 
-    assert casper.dynasty_wei_delta(casper.dynasty() + 1) == 0
+    assert concise_casper.dynasty_wei_delta(concise_casper.dynasty() + 1) == 0
+
     # Save deposit before slashing
-    validator_deposit = casper.deposit_size(validator_index)
+    validator_deposit = concise_casper.deposit_size(validator_index)
+    casper.functions.slash(vote_1, vote_2).transact({'from': base_sender})
 
-    casper.slash(vote_1, vote_2)
     # Slashed!
-    assert casper.validators__is_slashed(validator_index)
+    assert concise_casper.validators__is_slashed(validator_index)
 
     # Slash log
-    log = get_last_log(casper_chain, casper)
-    log_fields = {'_event_type', '_from', '_offender', '_offender_index', '_bounty', '_destroyed'}
+    logs = casper_slash_filter.get_new_entries()
+    assert len(logs) == 1
+    log = logs[-1]['args']
+
+    log_fields = {
+        '_from',
+        '_offender',
+        '_offender_index',
+        '_bounty',
+    }
     assert log_fields == log.keys()
-    assert log['_event_type'] == b'Slash'
-    assert log['_from'] == '0x' + utils.encode_hex(utils.privtoaddr(base_sender_privkey))
-    assert log['_offender'] == '0x' + utils.encode_hex(utils.privtoaddr(funded_privkey))
+    assert log['_from'] == base_sender
+    assert log['_offender'] == funded_account
     assert log['_offender_index'] == validator_index
     assert log['_bounty'] == math.floor(validator_deposit / 25)
-    assert log['_destroyed'] == validator_deposit - log['_bounty']

--- a/tests/test_multiple_validators.py
+++ b/tests/test_multiple_validators.py
@@ -1,106 +1,171 @@
-def test_deposits(casper, funded_privkeys, deposit_amount, new_epoch, induct_validators):
-    induct_validators(funded_privkeys, [deposit_amount] * len(funded_privkeys))
-    assert casper.total_curdyn_deposits_in_wei() == deposit_amount * len(funded_privkeys)
-    assert casper.total_prevdyn_deposits_in_wei() == 0
 
 
-def test_deposits_on_staggered_dynasties(casper, funded_privkeys, deposit_amount, new_epoch,
-                                         induct_validator, deposit_validator, mk_suggested_vote):
-    initial_validator = induct_validator(funded_privkeys[0], deposit_amount)
+def test_deposits(concise_casper,
+                  funded_accounts,
+                  validation_keys,
+                  deposit_amount,
+                  new_epoch,
+                  induct_validators):
+    induct_validators(
+        funded_accounts,
+        validation_keys,
+        [deposit_amount] * len(funded_accounts)
+    )
+    assert concise_casper.total_curdyn_deposits_in_wei() == deposit_amount * len(funded_accounts)
+    assert concise_casper.total_prevdyn_deposits_in_wei() == 0
+
+
+def test_deposits_on_staggered_dynasties(casper,
+                                         concise_casper,
+                                         funded_accounts,
+                                         validation_keys,
+                                         deposit_amount,
+                                         new_epoch,
+                                         induct_validator,
+                                         deposit_validator,
+                                         mk_suggested_vote):
+    initial_validator = induct_validator(funded_accounts[0], validation_keys[0], deposit_amount)
 
     # finalize some epochs with just the one validator
     for i in range(3):
-        casper.vote(mk_suggested_vote(initial_validator, funded_privkeys[0]))
+        casper.functions.vote(
+            mk_suggested_vote(initial_validator, validation_keys[0])
+        ).transact()
         new_epoch()
 
     # induct more validators
-    for privkey in funded_privkeys[1:]:
-        deposit_validator(privkey, deposit_amount)
+    for account, key in zip(funded_accounts[1:], validation_keys[1:]):
+        deposit_validator(account, key, deposit_amount)
 
-    assert casper.deposit_size(initial_validator) == casper.total_curdyn_deposits_in_wei()
+    assert concise_casper.deposit_size(initial_validator) == \
+        concise_casper.total_curdyn_deposits_in_wei()
 
-    casper.vote(mk_suggested_vote(initial_validator, funded_privkeys[0]))
+    casper.functions.vote(
+        mk_suggested_vote(initial_validator, validation_keys[0])
+    ).transact()
     new_epoch()
-    assert casper.deposit_size(initial_validator) == casper.total_curdyn_deposits_in_wei()
+    assert concise_casper.deposit_size(initial_validator) == \
+        concise_casper.total_curdyn_deposits_in_wei()
 
-    casper.vote(mk_suggested_vote(initial_validator, funded_privkeys[0]))
+    casper.functions.vote(
+        mk_suggested_vote(initial_validator, validation_keys[0])
+    ).transact()
     new_epoch()
-    assert casper.deposit_size(initial_validator) == casper.total_prevdyn_deposits_in_wei()
+    assert concise_casper.deposit_size(initial_validator) == \
+        concise_casper.total_prevdyn_deposits_in_wei()
 
 
-def test_justification_and_finalization(casper, funded_privkeys, deposit_amount, new_epoch,
-                                        induct_validators, mk_suggested_vote):
-    validator_indexes = induct_validators(funded_privkeys, [deposit_amount] * len(funded_privkeys))
-    assert casper.total_curdyn_deposits_in_wei() == deposit_amount * len(funded_privkeys)
+def test_justification_and_finalization(casper,
+                                        concise_casper,
+                                        funded_accounts,
+                                        validation_keys,
+                                        deposit_amount,
+                                        new_epoch,
+                                        induct_validators,
+                                        mk_suggested_vote):
+    validator_indexes = induct_validators(
+        funded_accounts,
+        validation_keys,
+        [deposit_amount] * len(funded_accounts)
+    )
+    assert concise_casper.total_curdyn_deposits_in_wei() == deposit_amount * len(funded_accounts)
 
-    prev_dynasty = casper.dynasty()
+    prev_dynasty = concise_casper.dynasty()
     for _ in range(10):
-        for i, validator_index in enumerate(validator_indexes):
-            casper.vote(mk_suggested_vote(validator_index, funded_privkeys[i]))
-        assert casper.main_hash_justified()
-        assert casper.checkpoints__is_finalized(casper.recommended_source_epoch())
+        for key, validator_index in zip(validation_keys, validator_indexes):
+            casper.functions.vote(
+                mk_suggested_vote(validator_index, key)
+            ).transact()
+        assert concise_casper.main_hash_justified()
+        assert concise_casper.checkpoints__is_finalized(concise_casper.recommended_source_epoch())
         new_epoch()
-        assert casper.dynasty() == prev_dynasty + 1
+        assert concise_casper.dynasty() == prev_dynasty + 1
         prev_dynasty += 1
 
 
-def test_voters_make_more(casper, funded_privkeys, deposit_amount, new_epoch,
-                          induct_validators, mk_suggested_vote):
-    validator_indexes = induct_validators(funded_privkeys, [deposit_amount] * len(funded_privkeys))
-    assert casper.total_curdyn_deposits_in_wei() == deposit_amount * len(funded_privkeys)
+def test_voters_make_more(casper,
+                          concise_casper,
+                          funded_accounts,
+                          validation_keys,
+                          deposit_amount,
+                          new_epoch,
+                          induct_validators,
+                          mk_suggested_vote):
+    validator_indexes = induct_validators(
+        funded_accounts,
+        validation_keys,
+        [deposit_amount] * len(funded_accounts)
+    )
+    assert concise_casper.total_curdyn_deposits_in_wei() == deposit_amount * len(funded_accounts)
 
     nonvoting_index = validator_indexes[0]
     voting_indexes = validator_indexes[1:]
-    voting_privkeys = funded_privkeys[1:]
+    voting_keys = validation_keys[1:]
 
-    prev_dynasty = casper.dynasty()
+    prev_dynasty = concise_casper.dynasty()
     for _ in range(10):
-        for i, validator_index in enumerate(voting_indexes):
-            casper.vote(mk_suggested_vote(validator_index, voting_privkeys[i]))
-        assert casper.main_hash_justified()
-        assert casper.checkpoints__is_finalized(casper.recommended_source_epoch())
+        for key, validator_index in zip(voting_keys, voting_indexes):
+            casper.functions.vote(
+                mk_suggested_vote(validator_index, key)
+            ).transact()
+        assert concise_casper.main_hash_justified()
+        assert concise_casper.checkpoints__is_finalized(concise_casper.recommended_source_epoch())
         new_epoch()
-        assert casper.dynasty() == prev_dynasty + 1
+        assert concise_casper.dynasty() == prev_dynasty + 1
         prev_dynasty += 1
 
-    voting_deposits = list(map(casper.deposit_size, voting_indexes))
-    nonvoting_deposit = casper.deposit_size(nonvoting_index)
+    voting_deposits = list(map(concise_casper.deposit_size, voting_indexes))
+    nonvoting_deposit = concise_casper.deposit_size(nonvoting_index)
     assert len(set(voting_deposits)) == 1
     assert voting_deposits[0] > nonvoting_deposit
 
 
-def test_partial_online(casper, funded_privkeys, deposit_amount, new_epoch,
-                        induct_validators, mk_suggested_vote):
-    validator_indexes = induct_validators(funded_privkeys, [deposit_amount] * len(funded_privkeys))
-    assert casper.total_curdyn_deposits_in_wei() == deposit_amount * len(funded_privkeys)
+def test_partial_online(casper,
+                        concise_casper,
+                        funded_accounts,
+                        validation_keys,
+                        deposit_amount,
+                        new_epoch,
+                        induct_validators,
+                        mk_suggested_vote):
+    validator_indexes = induct_validators(
+        funded_accounts,
+        validation_keys,
+        [deposit_amount] * len(funded_accounts)
+    )
+    assert concise_casper.total_curdyn_deposits_in_wei() == deposit_amount * len(funded_accounts)
 
     half_index = int(len(validator_indexes) / 2)
     online_indexes = validator_indexes[0:half_index]
-    online_privkeys = funded_privkeys[0:half_index]
+    online_keys = validation_keys[0:half_index]
     offline_indexes = validator_indexes[half_index:-1]
 
-    total_online_deposits = sum(map(casper.deposit_size, online_indexes))
-    prev_ovp = total_online_deposits / casper.total_curdyn_deposits_in_wei()
+    total_online_deposits = sum(map(concise_casper.deposit_size, online_indexes))
+    prev_ovp = total_online_deposits / concise_casper.total_curdyn_deposits_in_wei()
 
     for i in range(100):
-        for i, validator_index in enumerate(online_indexes):
-            casper.vote(mk_suggested_vote(validator_index, online_privkeys[i]))
+        for key, validator_index in zip(online_keys, online_indexes):
+            casper.functions.vote(
+                mk_suggested_vote(validator_index, key)
+            ).transact()
 
-        total_online_deposits = sum(map(casper.deposit_size, online_indexes))
-        ovp = total_online_deposits / casper.total_curdyn_deposits_in_wei()
+        total_online_deposits = sum(map(concise_casper.deposit_size, online_indexes))
+        ovp = total_online_deposits / concise_casper.total_curdyn_deposits_in_wei()
 
         # after two non-finalized epochs, offline voters should start losing more
         if i >= 2:
             assert ovp > prev_ovp
 
         if ovp >= 0.75:
-            assert casper.main_hash_justified()
-            assert casper.checkpoints__is_finalized(casper.recommended_source_epoch())
+            assert concise_casper.main_hash_justified()
+            assert concise_casper.checkpoints__is_finalized(
+                concise_casper.recommended_source_epoch()
+            )
             break
 
         new_epoch()
         prev_ovp = ovp
 
-    online_validator_deposit_size = sum(map(casper.deposit_size, online_indexes))
-    offline_validator_deposit_size = sum(map(casper.deposit_size, offline_indexes))
+    online_validator_deposit_size = sum(map(concise_casper.deposit_size, online_indexes))
+    offline_validator_deposit_size = sum(map(concise_casper.deposit_size, offline_indexes))
     assert online_validator_deposit_size > offline_validator_deposit_size

--- a/tests/test_purity_checker.py
+++ b/tests/test_purity_checker.py
@@ -25,13 +25,19 @@ def build_pass_fail_matrix():
     "valcode_type,should_succeed",
     build_pass_fail_matrix()
 )
-def test_valcode_purity_checks(casper, funded_privkey, assert_tx_failed,
-                               deposit_amount, deposit_validator,
-                               valcode_type, should_succeed,
-                               validation_addr):
+def test_valcode_purity_checks(casper,
+                               funded_account,
+                               validation_key,
+                               assert_tx_failed,
+                               deposit_amount,
+                               deposit_validator,
+                               valcode_type,
+                               should_succeed,
+                               deploy_validation_contract):
     if should_succeed:
         deposit_validator(
-            funded_privkey,
+            funded_account,
+            validation_key,
             deposit_amount,
             valcode_type
         )
@@ -43,9 +49,10 @@ def test_valcode_purity_checks(casper, funded_privkey, assert_tx_failed,
         checker, instead are a result of a bug in the contract being
         tested.
         '''
-        validation_addr(funded_privkey, valcode_type)
+        deploy_validation_contract(funded_account, valcode_type)
         assert_tx_failed(lambda: deposit_validator(
-            funded_privkey,
+            funded_account,
+            validation_key,
             deposit_amount,
             valcode_type
         ))

--- a/tests/utils/common_assertions.py
+++ b/tests/utils/common_assertions.py
@@ -1,6 +1,3 @@
-ZERO_ADDR = "0x" + "00" * 20
-
-
 def assert_validator_empty(casper, validator_index):
     assert casper.deposit_size(validator_index) == 0
     assert casper.validators__deposit(validator_index) == 0
@@ -8,5 +5,5 @@ def assert_validator_empty(casper, validator_index):
     assert casper.validators__end_dynasty(validator_index) == 0
     assert not casper.validators__is_slashed(validator_index)
     assert casper.validators__total_deposits_at_logout(validator_index) == 0
-    assert casper.validators__addr(validator_index) == ZERO_ADDR
-    assert casper.validators__withdrawal_addr(validator_index) == ZERO_ADDR
+    assert not casper.validators__addr(validator_index)
+    assert not casper.validators__withdrawal_addr(validator_index)

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -1,0 +1,5 @@
+from web3 import Web3
+
+
+def encode_int32(val):
+    return Web3.toBytes(val).rjust(32, b'\x00')

--- a/tests/utils/valcodes.py
+++ b/tests/utils/valcodes.py
@@ -24,7 +24,7 @@ def generate_pure_ecrecover_LLL_source(address):
                         0,
                         ['eq',
                             ['mload', 0],
-                            Web3.toInt(address)]],
+                            Web3.toInt(hexstr=address)]],
                     ['return', 0, 32]],
                 [0]]]
     ]
@@ -43,7 +43,7 @@ def format_LLL_source(address, expression):
                         0,
                         ['eq',
                             ['mload', 0],
-                            Web3.toInt(address)]],
+                            Web3.toInt(hexstr=address)]],
                     ['return', 0, 32]],
                 [0]]]
     ]
@@ -79,11 +79,14 @@ def format_ecrecover_bytecode(address, opcode):
     pure_ecrecover_bytecode = (
         "61003f56{start:02x}5060806000600037602060006080600060006001610"
         "bb8f15073{address}6000511460005260206000f35b61000461003f036100"
-        "0460003961000461003f036000f3")
+        "0460003961000461003f036000f3"
+    )
     return bytes.fromhex(
         pure_ecrecover_bytecode.format(
             start=opcode,
-            address=address.hex()))
+            address=address[2:]
+        )
+    )
 
 
 def generate_unused_opcodes_as_evm_bytecode(address):

--- a/tests/utils/valcodes.py
+++ b/tests/utils/valcodes.py
@@ -1,6 +1,6 @@
 from vyper import optimizer, compile_lll
 from vyper.parser.parser_utils import LLLnode
-from ethereum.utils import bytes_to_int
+from web3 import Web3
 
 
 # We must know a pure opcode so we can do control tests
@@ -24,7 +24,7 @@ def generate_pure_ecrecover_LLL_source(address):
                         0,
                         ['eq',
                             ['mload', 0],
-                            bytes_to_int(address)]],
+                            Web3.toInt(address)]],
                     ['return', 0, 32]],
                 [0]]]
     ]
@@ -43,7 +43,7 @@ def format_LLL_source(address, expression):
                         0,
                         ['eq',
                             ['mload', 0],
-                            bytes_to_int(address)]],
+                            Web3.toInt(address)]],
                     ['return', 0, 32]],
                 [0]]]
     ]

--- a/tests/utils/valcodes.py
+++ b/tests/utils/valcodes.py
@@ -126,7 +126,7 @@ def generate_all_valcodes(address):
 
 
 def all_known_valcode_types():
-    return generate_all_valcodes(b'\x00').keys()
+    return generate_all_valcodes('0x00').keys()
 
 
 def compile_valcode_to_evm_bytecode(valcode_type, address):


### PR DESCRIPTION
addresses #150 and #111 

- remove pyethereum dependency
- add eth-tester and web3.py
- currently build from a specific commit on vyper rather than a version release
- upgrade pyrlp
- upgrade vyper array type declarations
- port all tests

I'm pretty sure the tests run much slower because of inefficient  setup that is happening with every test. Will look into it.