### PR TITLE
Logged in check description mismatch

### DIFF
--- a/VALIDATOR_GUIDE.md
+++ b/VALIDATOR_GUIDE.md
@@ -152,7 +152,7 @@ Once a validator is logged in, they can use the following logic to determine whe
 
 NOTE: To check if a validator is logged in, one can use:
 ``` python
-return casper.validators__start_dynasty(validator_index) >= casper.dynasty()
+return casper.validators__start_dynasty(validator_index) <= casper.dynasty()
 ```
 
 #### [[See the current validator implementation for more information.]](https://github.com/karlfloersch/pyethapp/blob/dev_env/pyethapp/validator_service.py)


### PR DESCRIPTION
From this line https://github.com/ethereum/casper/blob/master/casper/contracts/simple_casper.v.py#L606 it looks like `start_dynasty` must be less or equal to `current_dynasty` to pass the asset test below?