### PR TITLE
Prevent slash before start_dynasty

### DIFF
--- a/casper/contracts/simple_casper.v.py
+++ b/casper/contracts/simple_casper.v.py
@@ -373,6 +373,7 @@ def validate_vote_signature(vote_msg: bytes[1024]) -> bool:
 
     return self.validate_signature(msg_hash, sig, validator_index)
 
+
 @public
 # cannot be labeled @constant because of external call
 # even though the call is to a pure contract call
@@ -404,6 +405,8 @@ def slashable(vote_msg_1: bytes[1024], vote_msg_2: bytes[1024]) -> bool:
     if not self.validate_signature(msg_hash_2, sig_2, validator_index_2):
         return False
     if validator_index_1 != validator_index_2:
+        return False
+    if self.validators[validator_index_1].start_dynasty > self.dynasty:
         return False
     if msg_hash_1 == msg_hash_2:
         return False

--- a/tests/test_slashing.py
+++ b/tests/test_slashing.py
@@ -4,16 +4,15 @@ from utils.common_assertions import (
 from utils.utils import encode_int32
 
 
-def test_invalid_signature_fails(
-        casper,
-        concise_casper,
-        funded_account,
-        validation_key,
-        deposit_amount,
-        induct_validator,
-        mk_vote,
-        fake_hash,
-        assert_tx_failed):
+def test_invalid_signature_fails(casper,
+                                 concise_casper,
+                                 funded_account,
+                                 validation_key,
+                                 deposit_amount,
+                                 induct_validator,
+                                 mk_vote,
+                                 fake_hash,
+                                 assert_tx_failed):
     validator_index = induct_validator(funded_account, validation_key, deposit_amount)
 
     # construct double votes but one has an invalid signature
@@ -44,16 +43,15 @@ def test_invalid_signature_fails(
     )
 
 
-def test_different_validators_fails(
-        casper,
-        concise_casper,
-        funded_accounts,
-        validation_keys,
-        deposit_amount,
-        induct_validators,
-        mk_vote,
-        fake_hash,
-        assert_tx_failed):
+def test_different_validators_fails(casper,
+                                    concise_casper,
+                                    funded_accounts,
+                                    validation_keys,
+                                    deposit_amount,
+                                    induct_validators,
+                                    mk_vote,
+                                    fake_hash,
+                                    assert_tx_failed):
     validator_indexes = induct_validators(
         funded_accounts,
         validation_keys,
@@ -128,6 +126,28 @@ def test_double_slash_fails(casper,
 
     assert concise_casper.slashable(vote_1, vote_2)
     casper.functions.slash(vote_1, vote_2).transact()
+
+    assert not concise_casper.slashable(vote_1, vote_2)
+    assert_tx_failed(
+        lambda: casper.functions.slash(vote_1, vote_2).transact()
+    )
+
+
+def test_slash_before_start_dynasty_fails(casper,
+                                    concise_casper,
+                                    funded_account,
+                                    validation_key,
+                                    deposit_amount,
+                                    deposit_validator,
+                                    mk_slash_votes,
+                                    new_epoch,
+                                    assert_tx_failed):
+    new_epoch()
+    validator_index = deposit_validator(funded_account, validation_key, deposit_amount)
+
+    vote_1, vote_2 = mk_slash_votes(validator_index, validation_key)
+
+    assert concise_casper.validators__start_dynasty(validator_index) > concise_casper.dynasty()
 
     assert not concise_casper.slashable(vote_1, vote_2)
     assert_tx_failed(


### PR DESCRIPTION
Addresses #146 

the simplest solution from the contract perspective was to prevent slashing until start_dynasty is reached. Any other solution required a lot of extra contract logic to handle updating dynasty_wei_delta and a other details...

I think this is the best solution, but am open to discussion.

This is built off of #165. so #165 should be merged and reviewed first.