### PR TITLE
Add .gitattributes file for Vyper syntax highlight on github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.vy linguist-language=Python


### PR DESCRIPTION
> Since .vy is not official a language supported by any syntax highlights or linter, it is recommended to name your vyper file into .v.py to have a python highlights. Alternative for GitHub syntax highlighting: Add a .gitattributes file with the line *.vy linguist-language=Python

See https://github.com/ethereum/vyper/blob/master/README.md#compiling-a-contract